### PR TITLE
Fix #22

### DIFF
--- a/src/main/java/binnie/botany/farm/CircuitGarden.java
+++ b/src/main/java/binnie/botany/farm/CircuitGarden.java
@@ -4,16 +4,15 @@
 
 package binnie.botany.farm;
 
-import net.minecraft.item.ItemStack;
-
-import forestry.api.circuits.ChipsetManager;
-import forestry.api.farming.FarmDirection;
-import forestry.api.farming.IFarmHousing;
-import forestry.api.farming.IFarmLogic;
 import binnie.Binnie;
 import binnie.botany.api.EnumAcidity;
 import binnie.botany.api.EnumMoisture;
 import binnie.core.circuits.BinnieCircuit;
+import forestry.api.circuits.ChipsetManager;
+import forestry.api.farming.FarmDirection;
+import forestry.api.farming.IFarmHousing;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 
 public class CircuitGarden extends BinnieCircuit
 {
@@ -35,31 +34,31 @@ public class CircuitGarden extends BinnieCircuit
 		this.icon = icon;
 		String info = "";
 		if (moisture == EnumMoisture.Dry) {
-			info += "§eDry§f";
+			info += EnumChatFormatting.YELLOW + "Dry" + EnumChatFormatting.RESET;
 		}
 		if (moisture == EnumMoisture.Damp) {
-			info += "§9Damp§f";
+			info += EnumChatFormatting.YELLOW + "Damp" + EnumChatFormatting.RESET;
 		}
 		if (this.acidity == EnumAcidity.Acid) {
 			if (info.length() > 0) {
 				info += ", ";
 			}
-			info += "§cAcidic§f";
+			info += EnumChatFormatting.RED + "Acidic" + EnumChatFormatting.RESET;
 		}
 		if (this.acidity == EnumAcidity.Neutral) {
 			if (info.length() > 0) {
 				info += ", ";
 			}
-			info += "§aNeutral§f";
+			info += EnumChatFormatting.GREEN + "Neutral" + EnumChatFormatting.RESET;
 		}
 		if (this.acidity == EnumAcidity.Alkaline) {
 			if (info.length() > 0) {
 				info += ", ";
 			}
-			info += "§bAlkaline§f";
+			info += EnumChatFormatting.AQUA + "Alkaline" + EnumChatFormatting.RESET;
 		}
 		if (info.length() > 0) {
-			info = " (" + info + "§f)";
+			info = " (" + info + EnumChatFormatting.RESET + ")";
 		}
 		this.addTooltipString("Flowers" + info);
 	}

--- a/src/main/java/binnie/botany/flower/ItemBotany.java
+++ b/src/main/java/binnie/botany/flower/ItemBotany.java
@@ -4,37 +4,37 @@
 
 package binnie.botany.flower;
 
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.block.Block;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.entity.Entity;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.init.Blocks;
-import binnie.botany.Botany;
-import forestry.api.genetics.IPollinatable;
 import binnie.Binnie;
-import binnie.botany.api.EnumFlowerStage;
-import net.minecraft.world.World;
-import binnie.botany.api.IFlowerType;
-import binnie.botany.genetics.EnumFlowerType;
-import net.minecraft.util.IIcon;
-import forestry.core.config.Config;
-import net.minecraft.creativetab.CreativeTabs;
-import binnie.botany.api.EnumFlowerChromosome;
-import binnie.botany.core.BotanyCore;
-import binnie.botany.api.IAlleleFlowerSpecies;
-import binnie.botany.genetics.Flower;
-import net.minecraft.client.renderer.texture.IIconRegister;
-import binnie.core.BinnieCore;
-import binnie.botany.api.IFlower;
-import java.util.List;
-import net.minecraft.entity.player.EntityPlayer;
-import forestry.api.genetics.IIndividual;
-import net.minecraft.item.ItemStack;
+import binnie.botany.Botany;
 import binnie.botany.CreativeTabBotany;
+import binnie.botany.api.EnumFlowerChromosome;
+import binnie.botany.api.EnumFlowerStage;
+import binnie.botany.api.IAlleleFlowerSpecies;
+import binnie.botany.api.IFlower;
+import binnie.botany.api.IFlowerType;
+import binnie.botany.core.BotanyCore;
+import binnie.botany.genetics.EnumFlowerType;
+import binnie.botany.genetics.Flower;
+import binnie.core.BinnieCore;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import forestry.api.genetics.IIndividual;
+import forestry.api.genetics.IPollinatable;
+import forestry.core.config.Config;
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+import java.util.List;
 
 public abstract class ItemBotany extends Item
 {
@@ -84,13 +84,15 @@ public abstract class ItemBotany extends Item
 			list.add("This item is bugged. Destroy it!");
 			return;
 		}
-		list.add("§e" + individual.getGenome().getPrimaryColor().getName() + ((individual.getGenome().getPrimaryColor() == individual.getGenome().getSecondaryColor()) ? "" : (" and " + individual.getGenome().getSecondaryColor().getName())) + ", " + individual.getGenome().getStemColor().getName() + " Stem");
+
+		list.add(EnumChatFormatting.YELLOW + individual.getGenome().getPrimaryColor().getName() + ((individual.getGenome().getPrimaryColor() == individual.getGenome().getSecondaryColor()) ? "" : (" and " + individual.getGenome().getSecondaryColor().getName())) + ", " + individual.getGenome().getStemColor().getName() + " Stem");
 		if (individual.isAnalyzed()) {
 			if (BinnieCore.proxy.isShiftDown()) {
 				individual.addTooltip(list);
 			}
 			else {
-				list.add("§o<Hold shift for details>");
+				// TODO remove hardcode strings and localize
+				list.add(EnumChatFormatting.GRAY + "<Hold shift for details>");
 			}
 		}
 		else {

--- a/src/main/java/binnie/botany/gardening/ItemSoil.java
+++ b/src/main/java/binnie/botany/gardening/ItemSoil.java
@@ -4,16 +4,18 @@
 
 package binnie.botany.gardening;
 
-import net.minecraft.block.Block;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import binnie.botany.api.EnumAcidity;
 import binnie.botany.api.EnumMoisture;
-import java.util.List;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import binnie.botany.api.EnumSoilType;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.List;
 
 public class ItemSoil extends ItemBlock
 {
@@ -28,22 +30,22 @@ public class ItemSoil extends ItemBlock
 		final EnumAcidity acidity = EnumAcidity.values()[stack.getItemDamage() / 3];
 		String info = "";
 		if (moisture == EnumMoisture.Dry) {
-			info += "§eDry§f";
+			info += EnumChatFormatting.YELLOW + "Dry" + EnumChatFormatting.RESET;
 		}
 		if (moisture == EnumMoisture.Damp) {
-			info += "§9Damp§f";
+			info += EnumChatFormatting.YELLOW + "Damp" + EnumChatFormatting.RESET;
 		}
 		if (acidity == EnumAcidity.Acid) {
 			if (info.length() > 0) {
 				info += ", ";
 			}
-			info += "§cAcidic§f";
+			info += EnumChatFormatting.RED + "Acidic" + EnumChatFormatting.RESET;
 		}
 		if (acidity == EnumAcidity.Alkaline) {
 			if (info.length() > 0) {
 				info += ", ";
 			}
-			info += "§bAlkaline§f";
+			info += EnumChatFormatting.AQUA + "Alkaline" + EnumChatFormatting.RESET;
 		}
 		if (info.length() > 0) {
 			p_77624_3_.add(info);

--- a/src/main/java/binnie/botany/gardening/ItemSoilMeter.java
+++ b/src/main/java/binnie/botany/gardening/ItemSoilMeter.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import binnie.botany.Botany;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import binnie.botany.api.EnumAcidity;
 import binnie.botany.api.EnumMoisture;
@@ -37,12 +38,31 @@ public class ItemSoilMeter extends Item
 			final EnumSoilType type = soil.getType(world, x, y, z);
 			final EnumMoisture moisture = soil.getMoisture(world, x, y, z);
 			final EnumAcidity pH = soil.getPH(world, x, y, z);
+
+			// TODO remove hardcode strings ans localize
+			EnumChatFormatting[] colors = new EnumChatFormatting[] {
+				EnumChatFormatting.DARK_GRAY,
+				EnumChatFormatting.GOLD,
+				EnumChatFormatting.LIGHT_PURPLE,
+			};
 			String info = "Type: ";
-			info = info + "§" + (new char[] { '8', '6', 'd' })[type.ordinal()] + Binnie.Language.localise(type) + "§f";
+			info += colors[type.ordinal()] + Binnie.Language.localise(type) + EnumChatFormatting.RESET;
+
+			colors = new EnumChatFormatting[] {
+				EnumChatFormatting.YELLOW,
+				EnumChatFormatting.GRAY,
+				EnumChatFormatting.BLUE,
+			};
 			info += ", Moisture: ";
-			info = info + "§" + (new char[] { 'e', '7', '9' })[moisture.ordinal()] + Binnie.Language.localise(moisture) + "§f";
+			info += colors[moisture.ordinal()] + Binnie.Language.localise(moisture) + EnumChatFormatting.RESET;
+
+			colors = new EnumChatFormatting[] {
+				EnumChatFormatting.RED,
+				EnumChatFormatting.GREEN,
+				EnumChatFormatting.AQUA,
+			};
 			info += ", pH: ";
-			info = info + "§" + (new char[] { 'c', 'a', 'b' })[pH.ordinal()] + Binnie.Language.localise(pH) + "§f";
+			info += colors[pH.ordinal()] + Binnie.Language.localise(pH) + EnumChatFormatting.RESET;
 			final IChatComponent chat = new ChatComponentText(info);
 			player.addChatMessage(chat);
 		}

--- a/src/main/java/binnie/botany/genetics/Flower.java
+++ b/src/main/java/binnie/botany/genetics/Flower.java
@@ -4,26 +4,25 @@
 
 package binnie.botany.genetics;
 
-import binnie.botany.api.IFlowerColour;
-import forestry.api.genetics.IGenome;
-import binnie.botany.api.IFlowerMutation;
-import binnie.botany.api.IColourMix;
-import forestry.api.arboriculture.EnumTreeChromosome;
-import net.minecraft.world.World;
-import forestry.api.genetics.IAllele;
-import forestry.core.genetics.Chromosome;
-import forestry.api.genetics.IChromosome;
-import java.util.Random;
-import net.minecraft.nbt.NBTBase;
-import binnie.botany.core.BotanyCore;
-import forestry.api.genetics.IChromosomeType;
 import binnie.botany.api.EnumFlowerChromosome;
-import java.util.List;
 import binnie.botany.api.IAlleleFlowerSpecies;
-import net.minecraft.nbt.NBTTagCompound;
-import binnie.botany.api.IFlowerGenome;
+import binnie.botany.api.IColourMix;
 import binnie.botany.api.IFlower;
+import binnie.botany.api.IFlowerColour;
+import binnie.botany.api.IFlowerGenome;
+import binnie.botany.api.IFlowerMutation;
+import binnie.botany.core.BotanyCore;
+import forestry.api.arboriculture.EnumTreeChromosome;
+import forestry.api.genetics.IAllele;
+import forestry.api.genetics.IChromosome;
+import forestry.core.genetics.Chromosome;
 import forestry.core.genetics.Individual;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
+
+import java.util.List;
+import java.util.Random;
 
 public class Flower extends Individual implements IFlower
 {
@@ -66,17 +65,19 @@ public class Flower extends Individual implements IFlower
 	}
 
 	@Override
-	public void addTooltip(final List<String> list) {
-		final IAlleleFlowerSpecies primary = this.genome.getPrimary();
-		final IAlleleFlowerSpecies secondary = this.genome.getSecondary();
-		if (!this.isPureBred(EnumFlowerChromosome.SPECIES)) {
-			list.add("§9" + primary.getName() + "-" + secondary.getName() + " Hybrid");
+	public void addTooltip(List<String> list) {
+		IAlleleFlowerSpecies primary = genome.getPrimary();
+		IAlleleFlowerSpecies secondary = genome.getSecondary();
+		if (!isPureBred(EnumFlowerChromosome.SPECIES)) {
+			list.add(EnumChatFormatting.BLUE + primary.getName() + "-" + secondary.getName() + " Hybrid");
 		}
-		list.add("§6Age: " + this.getAge());
-		list.add("§6T: " + this.getGenome().getPrimary().getTemperature() + " / " + this.getGenome().getToleranceTemperature());
-		list.add("§6M: " + this.getGenome().getPrimary().getMoisture() + " / " + this.getGenome().getToleranceMoisture());
-		list.add("§6pH: " + this.getGenome().getPrimary().getHumidity() + " / " + this.getGenome().getTolerancePH());
-		list.add("§6Fert: " + this.getGenome().getFertility() + "x");
+
+		// TODO remove hardcode strings and localize
+		list.add(EnumChatFormatting.GRAY + "Age: " + getAge());
+		list.add(EnumChatFormatting.GREEN + "T: " + primary.getTemperature() + " / " + genome.getToleranceTemperature());
+		list.add(EnumChatFormatting.GREEN + "M: " + primary.getMoisture() + " / " + genome.getToleranceMoisture());
+		list.add(EnumChatFormatting.GREEN + "pH: " + primary.getHumidity() + " / " + genome.getTolerancePH());
+		list.add(EnumChatFormatting.GRAY + "Fert: " + genome.getFertility() + "x");
 	}
 
 	@Override

--- a/src/main/java/binnie/core/craftgui/database/PageBranchOverview.java
+++ b/src/main/java/binnie/core/craftgui/database/PageBranchOverview.java
@@ -5,6 +5,7 @@ import binnie.core.craftgui.IWidget;
 import binnie.core.craftgui.controls.ControlText;
 import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.genetics.IClassification;
+import net.minecraft.util.EnumChatFormatting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +26,9 @@ public class PageBranchOverview extends PageBranch {
 
 	@Override
 	public void onValueChanged(IClassification branch) {
-		pageBranchOverview_branchName.setValue("§n" + branch.getName() + " Branch§r");
-		pageBranchOverview_branchScientific.setValue("§oApidae " + branch.getScientific() + "§r");
-		pageBranchOverview_branchAuthority.setValue("Discovered by §l" + branch.getMemberSpecies()[0].getAuthority() + "§r");
+		pageBranchOverview_branchName.setValue(EnumChatFormatting.UNDERLINE + branch.getName() + " Branch" + EnumChatFormatting.RESET);
+		pageBranchOverview_branchScientific.setValue(EnumChatFormatting.ITALIC + "Apidae " + branch.getScientific() + EnumChatFormatting.RESET);
+		pageBranchOverview_branchAuthority.setValue("Discovered by " + EnumChatFormatting.BOLD + branch.getMemberSpecies()[0].getAuthority() + EnumChatFormatting.RESET);
 		for (IWidget widget : pageBranchOverview_branchDescription) {
 			deleteChild(widget);
 		}
@@ -42,7 +43,7 @@ public class PageBranchOverview extends PageBranch {
 		List<String> descLines = new ArrayList<String>();
 		for (String str : desc.split(" ")) {
 			if (CraftGUI.Render.textWidth(line + " " + str) > 134) {
-				descLines.add("§o" + line + "§r");
+				descLines.add(EnumChatFormatting.ITALIC + line + EnumChatFormatting.RESET);
 				line = "";
 			}
 			line = line + " " + str;

--- a/src/main/java/binnie/core/craftgui/database/PageBreeder.java
+++ b/src/main/java/binnie/core/craftgui/database/PageBreeder.java
@@ -6,6 +6,7 @@ import binnie.core.craftgui.controls.page.ControlPage;
 import binnie.core.craftgui.minecraft.Window;
 import binnie.core.genetics.BreedingSystem;
 import com.mojang.authlib.GameProfile;
+import net.minecraft.util.EnumChatFormatting;
 
 public class PageBreeder extends ControlPage<DatabaseTab> {
 	private GameProfile player;
@@ -23,7 +24,7 @@ public class PageBreeder extends ControlPage<DatabaseTab> {
 
 		BreedingSystem system = ((WindowAbstractDatabase) Window.get(this)).getBreedingSystem();
 		String descriptor = system.getDescriptor();
-		new ControlTextCentered(this, 8.0f, "§n" + system.getDescriptor() + " Profile§r");
+		new ControlTextCentered(this, 8.0f, EnumChatFormatting.UNDERLINE + system.getDescriptor() + " Profile" + EnumChatFormatting.RESET);
 		new ControlTextCentered(this, 75.0f, "" + system.discoveredSpeciesCount + "/" + system.totalSpeciesCount + " Species");
 		new ControlBreedingProgress(this, 20, 87, 102, 14, system, system.discoveredSpeciesPercentage);
 		new ControlTextCentered(this, 115.0f, "" + system.discoveredBranchCount + "/" + system.totalBranchCount + " Branches");
@@ -33,6 +34,6 @@ public class PageBreeder extends ControlPage<DatabaseTab> {
 			new ControlTextCentered(this, 155.0f, "" + system.discoveredSecretCount + "/" + system.totalSecretCount + " Secret Species");
 		}
 		new ControlTextCentered(this, 32.0f, player.getName());
-		new ControlTextCentered(this, 44.0f, "§o" + system.getEpitome() + "§r");
+		new ControlTextCentered(this, 44.0f, EnumChatFormatting.ITALIC + system.getEpitome() + EnumChatFormatting.RESET);
 	}
 }

--- a/src/main/java/binnie/core/craftgui/database/PageBreederStats.java
+++ b/src/main/java/binnie/core/craftgui/database/PageBreederStats.java
@@ -5,6 +5,7 @@ import binnie.core.craftgui.controls.ControlText;
 import binnie.core.craftgui.controls.ControlTextCentered;
 import binnie.core.craftgui.controls.core.Control;
 import binnie.core.genetics.BreedingSystem;
+import net.minecraft.util.EnumChatFormatting;
 
 // TODO unused class?
 public class PageBreederStats extends Control {
@@ -13,7 +14,7 @@ public class PageBreederStats extends Control {
 	public PageBreederStats(IWidget parent, int w, int h, String player) {
 		super(parent, 0.0f, 0.0f, w, h);
 		this.player = player;
-		ControlText pageBranchOverview_branchName = new ControlTextCentered(this, 8.0f, "§nStats§r");
+		ControlText pageBranchOverview_branchName = new ControlTextCentered(this, 8.0f, EnumChatFormatting.UNDERLINE + "§tats" + EnumChatFormatting.RESET);
 		BreedingSystem system = ((WindowAbstractDatabase) getSuperParent()).getBreedingSystem();
 	}
 }

--- a/src/main/java/binnie/core/craftgui/database/PageSpeciesOverview.java
+++ b/src/main/java/binnie/core/craftgui/database/PageSpeciesOverview.java
@@ -8,6 +8,7 @@ import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IPoint;
 import binnie.core.craftgui.geometry.TextJustification;
 import forestry.api.genetics.IAlleleSpecies;
+import net.minecraft.util.EnumChatFormatting;
 
 public class PageSpeciesOverview extends PageSpecies {
 	private ControlText controlName;
@@ -37,12 +38,12 @@ public class PageSpeciesOverview extends PageSpecies {
 		controlInd2.setSpecies(species, EnumDiscoveryState.Show);
 		String branchBinomial = (species.getBranch() != null) ? species.getBranch().getScientific() : "<Unknown>";
 		String branchName = (species.getBranch() != null) ? species.getBranch().getName() : "Unknown";
-		controlName.setValue("§n" + species.getName() + "§r");
-		controlScientific.setValue("§o" + branchBinomial + " " + species.getBinomial() + "§r");
-		controlAuthority.setValue("Discovered by §l" + species.getAuthority() + "§r");
+		controlName.setValue(EnumChatFormatting.UNDERLINE + species.getName() + EnumChatFormatting.RESET);
+		controlScientific.setValue(EnumChatFormatting.ITALIC + branchBinomial + " " + species.getBinomial() + EnumChatFormatting.RESET);
+		controlAuthority.setValue("Discovered by " + EnumChatFormatting.BOLD + species.getAuthority() + EnumChatFormatting.RESET);
 		controlComplexity.setValue("Complexity: " + species.getComplexity());
 		String desc = species.getDescription();
-		String descBody = "§o";
+		String descBody = EnumChatFormatting.ITALIC.toString();
 		String descSig = "";
 
 		if (desc == null || desc == "") {
@@ -58,8 +59,8 @@ public class PageSpeciesOverview extends PageSpecies {
 			}
 		}
 
-		controlDescription.setValue(descBody + "§r");
-		controlSignature.setValue(descSig + "§r");
+		controlDescription.setValue(descBody + EnumChatFormatting.RESET);
+		controlSignature.setValue(descSig + EnumChatFormatting.RESET);
 		float descHeight = CraftGUI.Render.textHeight(controlDescription.getValue(), controlDescription.getSize().x());
 		controlSignature.setPosition(new IPoint(controlSignature.pos().x(), controlDescription.getPosition().y() + descHeight + 10.0f));
 	}

--- a/src/main/java/binnie/core/craftgui/minecraft/EnumColor.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/EnumColor.java
@@ -1,11 +1,7 @@
-// 
-// Decompiled by Procyon v0.5.30
-// 
-
 package binnie.core.craftgui.minecraft;
 
-public enum EnumColor
-{
+// TODO replace to EnumChatFormatting?
+public enum EnumColor {
 	Black("Black", 0, '0'),
 	DarkBlue("Dark Blue", 170, '1'),
 	DarkGreen("Dark Green", 43520, '2'),
@@ -23,9 +19,9 @@ public enum EnumColor
 	Yellow("Yellow", 16777045, 'e'),
 	White("White", 16777215, 'f');
 
-	int colour;
-	String name;
-	char code;
+	protected int colour;
+	protected String name;
+	protected char code;
 
 	EnumColor(String name, int colour, char code) {
 		this.name = name;
@@ -38,7 +34,7 @@ public enum EnumColor
 	}
 
 	public String getCode() {
-		return "§" + code;
+		return String.valueOf(code);
 	}
 
 	@Override

--- a/src/main/java/binnie/core/craftgui/minecraft/EnumColor.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/EnumColor.java
@@ -34,7 +34,7 @@ public enum EnumColor {
 	}
 
 	public String getCode() {
-		return String.valueOf(code);
+		return "\u00a7" + code;
 	}
 
 	@Override

--- a/src/main/java/binnie/core/machines/inventory/AccessDirection.java
+++ b/src/main/java/binnie/core/machines/inventory/AccessDirection.java
@@ -1,5 +1,7 @@
 package binnie.core.machines.inventory;
 
+import net.minecraft.util.EnumChatFormatting;
+
 enum AccessDirection {
 	Both,
 	In,
@@ -59,15 +61,15 @@ enum AccessDirection {
 	public String getTextColour() {
 		switch (this) {
 			case Both:
-				return "§a";
+				return EnumChatFormatting.GREEN.toString();
 
 			case In:
-				return "§e";
+				return EnumChatFormatting.YELLOW.toString();
 
 			case Neither:
-				return "§c";
+				return EnumChatFormatting.RED.toString();
 		}
-		return "§b";
+		return EnumChatFormatting.AQUA.toString();
 	}
 
 	public int getShadeColour() {

--- a/src/main/java/binnie/extratrees/craftgui/dictionary/PagePlanksOverview.java
+++ b/src/main/java/binnie/extratrees/craftgui/dictionary/PagePlanksOverview.java
@@ -22,6 +22,7 @@ import binnie.core.craftgui.database.DatabaseTab;
 import binnie.core.craftgui.IWidget;
 import net.minecraft.item.ItemStack;
 import binnie.core.craftgui.database.PageAbstract;
+import net.minecraft.util.EnumChatFormatting;
 
 public class PagePlanksOverview extends PageAbstract<ItemStack>
 {
@@ -60,7 +61,7 @@ public class PagePlanksOverview extends PageAbstract<ItemStack>
 		if (type != null) {
 			desc = type.getDescription();
 		}
-		String descBody = "§o";
+		String descBody = EnumChatFormatting.ITALIC.toString();
 		String descSig = "";
 		if (desc == null || desc.length() == 0) {
 			descBody += BinnieCore.proxy.localise("gui.database.nodescription");
@@ -75,8 +76,8 @@ public class PagePlanksOverview extends PageAbstract<ItemStack>
 				descSig += descStrings[descStrings.length - 1];
 			}
 		}
-		controlDescription.setValue(descBody + "§r");
-		controlSignature.setValue(descSig + "§r");
+		controlDescription.setValue(descBody + EnumChatFormatting.RESET);
+		controlSignature.setValue(descSig + EnumChatFormatting.RESET);
 		final float descHeight = CraftGUI.Render.textHeight(controlDescription.getValue(), controlDescription.getSize().x());
 		controlSignature.setPosition(new IPoint(controlSignature.pos().x(), controlDescription.getPosition().y() + descHeight + 10.0f));
 	}

--- a/src/main/java/binnie/extratrees/item/ModuleItems.java
+++ b/src/main/java/binnie/extratrees/item/ModuleItems.java
@@ -116,7 +116,11 @@ public class ModuleItems implements IInitializable
 		CraftingManager.getInstance().getRecipeList().add(new ShapedOreRecipe(new ItemStack(ExtraTrees.itemHammer, 1, 0), new Object[] { "wiw", " s ", " s ", 'w', "plankWood", 'i', Items.iron_ingot, 's', Items.stick }));
 		CraftingManager.getInstance().getRecipeList().add(new ShapedOreRecipe(ExtraTreeItems.Yeast.get(8), new Object[] { " m ", "mbm", 'b', Items.bread, 'm', Blocks.brown_mushroom }));
 		CraftingManager.getInstance().getRecipeList().add(new ShapedOreRecipe(ExtraTreeItems.LagerYeast.get(8), new Object[] { "mbm", " m ", 'b', Items.bread, 'm', Blocks.brown_mushroom }));
-		GameRegistry.addRecipe(ExtraTreeItems.GrainWheat.get(5), new Object[] { " s ", "sss", " s ", 's', Items.wheat_seeds });
+		GameRegistry.addRecipe(
+			ExtraTreeItems.GrainWheat.get(5),
+			" s ", "sss", " s ",
+			's', Items.wheat_seeds
+		);
 		GameRegistry.addRecipe(new ShapedOreRecipe(
 			ExtraTreeItems.GrainBarley.get(3), new Object[] {
 				false,

--- a/src/main/java/binnie/genetics/craftgui/ControlSequencerProgress.java
+++ b/src/main/java/binnie/genetics/craftgui/ControlSequencerProgress.java
@@ -4,17 +4,19 @@
 
 package binnie.genetics.craftgui;
 
-import net.minecraft.item.ItemStack;
-import java.util.Random;
-import binnie.core.machines.Machine;
-import binnie.core.craftgui.minecraft.Window;
-import binnie.core.craftgui.geometry.TextJustification;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.window.Panel;
-import binnie.core.craftgui.minecraft.MinecraftGUI;
 import binnie.core.craftgui.IWidget;
 import binnie.core.craftgui.controls.ControlText;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.TextJustification;
+import binnie.core.craftgui.minecraft.MinecraftGUI;
+import binnie.core.craftgui.minecraft.Window;
 import binnie.core.craftgui.minecraft.control.ControlProgressBase;
+import binnie.core.craftgui.window.Panel;
+import binnie.core.machines.Machine;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.Random;
 
 public class ControlSequencerProgress extends ControlProgressBase
 {
@@ -37,16 +39,23 @@ public class ControlSequencerProgress extends ControlProgressBase
 			final Random rand = new Random(stack.getDisplayName().length());
 			String text = "";
 			final String[] codes = { "A", "T", "G", "C" };
-			final String[] colors = { "a", "d", "b", "c" };
+			EnumChatFormatting[] colors = {
+				EnumChatFormatting.GREEN,
+				EnumChatFormatting.LIGHT_PURPLE,
+				EnumChatFormatting.AQUA,
+				EnumChatFormatting.RED
+			};
+
 			for (int i = 0; i < 65; ++i) {
 				final int k = rand.nextInt(4);
 				final String code = codes[k];
 				if (rand.nextFloat() < this.progress) {
-					final String col = "§" + colors[k];
-					text = text + "§r" + col + "§l" + code;
+					String col = colors[k].toString();
+					text = text + EnumChatFormatting.RESET + col + EnumChatFormatting.BOLD + code;
 				}
 				else {
-					text = text + "§r§7§k§l" + code;
+					text = text + EnumChatFormatting.RESET + EnumChatFormatting.GRAY
+						+ EnumChatFormatting.OBFUSCATED + EnumChatFormatting.BOLD + code;
 				}
 			}
 			this.textControl.setValue(text);

--- a/src/main/java/binnie/genetics/craftgui/WindowGeneBank.java
+++ b/src/main/java/binnie/genetics/craftgui/WindowGeneBank.java
@@ -4,41 +4,43 @@
 
 package binnie.genetics.craftgui;
 
-import binnie.genetics.Genetics;
-import binnie.core.AbstractMod;
-import binnie.core.craftgui.geometry.IPoint;
-import binnie.core.craftgui.controls.ControlText;
-import java.util.Arrays;
-import forestry.api.genetics.IAllele;
-import java.util.List;
-import forestry.api.genetics.IChromosomeType;
-import java.util.Map;
-import binnie.core.craftgui.Tooltip;
-import binnie.core.craftgui.minecraft.control.ControlTabIcon;
-import binnie.core.craftgui.controls.tab.ControlTab;
-import binnie.core.craftgui.controls.tab.ControlTabBar;
-import binnie.core.craftgui.geometry.Position;
 import binnie.Binnie;
-import binnie.core.craftgui.events.EventTextEdit;
+import binnie.core.AbstractMod;
+import binnie.core.craftgui.Tooltip;
+import binnie.core.craftgui.controls.ControlText;
 import binnie.core.craftgui.controls.ControlTextEdit;
 import binnie.core.craftgui.controls.scroll.ControlScrollableContent;
-import binnie.core.craftgui.minecraft.MinecraftGUI;
-import binnie.core.craftgui.window.Panel;
-import binnie.core.craftgui.minecraft.control.ControlPlayerInventory;
+import binnie.core.craftgui.controls.tab.ControlTab;
+import binnie.core.craftgui.controls.tab.ControlTabBar;
 import binnie.core.craftgui.events.EventHandler;
-import binnie.core.genetics.BreedingSystem;
+import binnie.core.craftgui.events.EventTextEdit;
 import binnie.core.craftgui.events.EventValueChanged;
-import binnie.genetics.genetics.GeneTracker;
+import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.geometry.Position;
+import binnie.core.craftgui.minecraft.MinecraftGUI;
 import binnie.core.craftgui.minecraft.Window;
+import binnie.core.craftgui.minecraft.control.ControlPlayerInventory;
+import binnie.core.craftgui.minecraft.control.ControlTabIcon;
+import binnie.core.craftgui.window.Panel;
+import binnie.core.genetics.BreedingSystem;
+import binnie.core.genetics.Gene;
+import binnie.genetics.Genetics;
+import binnie.genetics.genetics.Engineering;
+import binnie.genetics.genetics.GeneTracker;
+import cpw.mods.fml.relauncher.Side;
+import forestry.api.genetics.IAllele;
+import forestry.api.genetics.IChromosomeType;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.entity.player.EntityPlayerMP;
-import binnie.genetics.genetics.Engineering;
-import binnie.core.genetics.Gene;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.entity.player.EntityPlayer;
-import cpw.mods.fml.relauncher.Side;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class WindowGeneBank extends WindowMachine
 {
@@ -157,8 +159,8 @@ public class WindowGeneBank extends WindowMachine
 				}
 			}
 		}
-		new ControlText(panelProject, new IPoint(4.0f, 4.0f), "§nFull Genome Project");
-		new ControlText(panelProject, new IPoint(4.0f, 18.0f), "§oSequenced §r" + seqGenes + "/" + totalGenes + " §oGenes");
+		new ControlText(panelProject, new IPoint(4.0f, 4.0f), EnumChatFormatting.UNDERLINE + "Full Genome Project");
+		new ControlText(panelProject, new IPoint(4.0f, 18.0f), EnumChatFormatting.ITALIC.toString() + EnumChatFormatting.YELLOW + "quenced " + EnumChatFormatting.RESET + seqGenes + "/" + totalGenes + " " + EnumChatFormatting.ITALIC + "Genes");
 	}
 
 	@Override

--- a/src/main/java/binnie/genetics/craftgui/WindowSequencer.java
+++ b/src/main/java/binnie/genetics/craftgui/WindowSequencer.java
@@ -28,6 +28,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.entity.player.EntityPlayer;
 import binnie.core.craftgui.controls.ControlText;
 import binnie.core.craftgui.resource.Texture;
+import net.minecraft.util.EnumChatFormatting;
 
 public class WindowSequencer extends WindowMachine
 {
@@ -46,7 +47,7 @@ public class WindowSequencer extends WindowMachine
 	@Override
 	public void recieveGuiNBT(final Side side, final EntityPlayer player, final String name, final NBTTagCompound nbt) {
 		if (side == Side.CLIENT && name.equals("username")) {
-			this.slotText.setValue("§8Genes will be sequenced by " + nbt.getString("username"));
+			this.slotText.setValue(EnumChatFormatting.DARK_GRAY + "Genes will be sequenced by " + nbt.getString("username"));
 		}
 		super.recieveGuiNBT(side, player, name, nbt);
 	}
@@ -61,7 +62,7 @@ public class WindowSequencer extends WindowMachine
 		slotTarget.assign(5);
 		x = 34;
 		y = 92;
-		this.slotText = new ControlText(this, new IArea(0.0f, y, this.w(), 12.0f), "§8Userless. Will not save sequences", TextJustification.MiddleCenter);
+		this.slotText = new ControlText(this, new IArea(0.0f, y, this.w(), 12.0f), EnumChatFormatting.DARK_GRAY + "Userless. Will not save sequences", TextJustification.MiddleCenter);
 		y += 20;
 		final ControlSlot slotDye = new ControlSlot(this, x, y);
 		slotDye.assign(0);

--- a/src/main/java/binnie/genetics/genetics/GeneArrayItem.java
+++ b/src/main/java/binnie/genetics/genetics/GeneArrayItem.java
@@ -4,19 +4,20 @@
 
 package binnie.genetics.genetics;
 
-import forestry.api.genetics.ISpeciesRoot;
-import net.minecraft.nbt.NBTBase;
-import net.minecraft.nbt.NBTTagList;
-import binnie.core.genetics.Gene;
-import net.minecraft.nbt.NBTTagCompound;
 import binnie.Binnie;
-import binnie.core.genetics.BreedingSystem;
 import binnie.core.BinnieCore;
-import java.util.ArrayList;
-import net.minecraft.item.ItemStack;
+import binnie.core.genetics.BreedingSystem;
+import binnie.core.genetics.Gene;
 import binnie.genetics.api.IGene;
-import java.util.List;
 import forestry.api.core.INBTTagable;
+import forestry.api.genetics.ISpeciesRoot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GeneArrayItem implements INBTTagable, IGeneItem
 {
@@ -52,7 +53,7 @@ public class GeneArrayItem implements INBTTagable, IGeneItem
 		final List<Object> totalList = new ArrayList<Object>();
 		for (final IGene gene : this.genes) {
 			final String chromosomeName = this.getBreedingSystem().getChromosomeName(gene.getChromosome());
-			totalList.add("§6" + chromosomeName + "§7: " + gene.getName());
+			totalList.add(EnumChatFormatting.GOLD + chromosomeName + EnumChatFormatting.GRAY + ": " + gene.getName());
 		}
 		if (totalList.size() < 4 || BinnieCore.proxy.isShiftDown()) {
 			list.addAll(totalList);

--- a/src/main/java/binnie/genetics/genetics/GeneItem.java
+++ b/src/main/java/binnie/genetics/genetics/GeneItem.java
@@ -4,16 +4,17 @@
 
 package binnie.genetics.genetics;
 
-import forestry.api.genetics.ISpeciesRoot;
-import net.minecraft.nbt.NBTBase;
-import binnie.core.genetics.Gene;
 import binnie.Binnie;
 import binnie.core.genetics.BreedingSystem;
-import java.util.List;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.item.ItemStack;
+import binnie.core.genetics.Gene;
 import binnie.genetics.api.IGene;
 import forestry.api.core.INBTTagable;
+import forestry.api.genetics.ISpeciesRoot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.List;
 
 public class GeneItem implements INBTTagable, IGeneItem
 {
@@ -55,7 +56,7 @@ public class GeneItem implements INBTTagable, IGeneItem
 	@Override
 	public void getInfo(final List list) {
 		final String chromosomeName = this.getBreedingSystem().getChromosomeName(this.gene.getChromosome());
-		list.add("§6" + chromosomeName + "§7: " + this.gene.getName());
+		list.add(EnumChatFormatting.GOLD + chromosomeName + EnumChatFormatting.GRAY + ": " + this.gene.getName());
 	}
 
 	public BreedingSystem getBreedingSystem() {

--- a/src/main/java/binnie/genetics/gui/AnalystPageAppearance.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageAppearance.java
@@ -8,6 +8,7 @@ import forestry.api.genetics.IAlleleSpecies;
 import binnie.botany.api.EnumFlowerStage;
 import binnie.core.craftgui.geometry.IPoint;
 import binnie.core.craftgui.CraftGUI;
+import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.opengl.GL11;
 import binnie.core.craftgui.minecraft.control.ControlIconDisplay;
 import binnie.botany.craftgui.ControlColourDisplay;
@@ -23,7 +24,7 @@ public class AnalystPageAppearance extends ControlAnalystPage
 		this.setColor(3355443);
 		int y = 4;
 		final IAlleleSpecies species = ind.getGenome().getPrimary();
-		new ControlTextCentered(this, y, "§nAppearance").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Appearance").setColor(this.getColor());
 		y += 12;
 		final ControlColourDisplay a = new ControlColourDisplay(this, this.w() / 2.0f - 28.0f, y);
 		a.setValue(ind.getGenome().getPrimaryColor());

--- a/src/main/java/binnie/genetics/gui/AnalystPageBehaviour.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageBehaviour.java
@@ -19,6 +19,7 @@ import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.genetics.IIndividual;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import net.minecraft.util.EnumChatFormatting;
 
 public class AnalystPageBehaviour extends ControlAnalystPage
 {
@@ -26,7 +27,7 @@ public class AnalystPageBehaviour extends ControlAnalystPage
 		super(parent, area);
 		this.setColor(6684723);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nBehaviour").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Behaviour").setColor(this.getColor());
 		y += 12;
 		if (ind instanceof IBee) {
 			final IBee bee = (IBee) ind;
@@ -34,7 +35,7 @@ public class AnalystPageBehaviour extends ControlAnalystPage
 			final int fertility = bee.getGenome().getFlowering();
 			new ControlTextCentered(this, y, "Pollinates nearby\n" + bee.getGenome().getFlowerProvider().getDescription()).setColor(this.getColor());
 			y += 20;
-			new ControlTextCentered(this, y, "§oEvery " + this.getTimeString(PluginApiculture.ticksPerBeeWorkCycle * 100.0f / fertility)).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Every " + this.getTimeString(PluginApiculture.ticksPerBeeWorkCycle * 100.0f / fertility)).setColor(this.getColor());
 			y += 22;
 			final IAlleleBeeEffect effect = bee.getGenome().getEffect();
 			final int[] t = bee.getGenome().getTerritory();
@@ -43,19 +44,19 @@ public class AnalystPageBehaviour extends ControlAnalystPage
 				final String loc = effectDesc.equals("") ? ("Effect: " + effect.getName()) : effectDesc;
 				new ControlText(this, new IArea(4.0f, y, this.w() - 8.0f, 0.0f), loc, TextJustification.TopCenter).setColor(this.getColor());
 				y += (int) (CraftGUI.Render.textHeight(loc, this.w() - 8.0f) + 1.0f);
-				new ControlTextCentered(this, y, "§oWithin " + (int) (t[0] / 2.0f) + " blocks").setColor(this.getColor());
+				new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Within " + (int) (t[0] / 2.0f) + " blocks").setColor(this.getColor());
 				y += 22;
 			}
-			new ControlTextCentered(this, y, "Territory: §o" + t[0] + "x" + t[1] + "x" + t[2]).setColor(this.getColor());
+			new ControlTextCentered(this, y, "Territory: " + EnumChatFormatting.ITALIC + t[0] + "x" + t[1] + "x" + t[2]).setColor(this.getColor());
 			y += 22;
 		}
 		if (ind instanceof IButterfly) {
 			final IButterfly bee2 = (IButterfly) ind;
-			new ControlTextCentered(this, y, "§oMetabolism: " + Binnie.Genetics.mothBreedingSystem.getAlleleName(EnumButterflyChromosome.METABOLISM, ind.getGenome().getActiveAllele(EnumButterflyChromosome.METABOLISM))).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Metabolism: " + Binnie.Genetics.mothBreedingSystem.getAlleleName(EnumButterflyChromosome.METABOLISM, ind.getGenome().getActiveAllele(EnumButterflyChromosome.METABOLISM))).setColor(this.getColor());
 			y += 20;
 			new ControlTextCentered(this, y, "Pollinates nearby\n" + bee2.getGenome().getFlowerProvider().getDescription()).setColor(this.getColor());
 			y += 20;
-			new ControlTextCentered(this, y, "§oEvery " + this.getTimeString(1500.0f)).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Every " + this.getTimeString(1500.0f)).setColor(this.getColor());
 			y += 22;
 			final IAlleleButterflyEffect effect2 = bee2.getGenome().getEffect();
 			if (!effect2.getUID().contains("None")) {

--- a/src/main/java/binnie/genetics/gui/AnalystPageClimate.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageClimate.java
@@ -4,28 +4,30 @@
 
 package binnie.genetics.gui;
 
-import java.util.List;
-import binnie.core.craftgui.geometry.IPoint;
-import forestry.api.core.EnumHumidity;
-import binnie.core.genetics.Tolerance;
-import forestry.api.core.EnumTemperature;
-import net.minecraftforge.common.BiomeDictionary;
-import net.minecraft.world.biome.BiomeGenBase;
-import java.util.ArrayList;
-import binnie.core.craftgui.controls.ControlText;
-import binnie.core.craftgui.geometry.TextJustification;
-import binnie.core.craftgui.controls.ControlTextCentered;
-import forestry.api.lepidopterology.EnumButterflyChromosome;
-import forestry.api.lepidopterology.IButterfly;
 import binnie.botany.api.EnumFlowerChromosome;
 import binnie.botany.api.IFlower;
-import forestry.api.apiculture.EnumBeeChromosome;
-import forestry.api.genetics.IAlleleTolerance;
-import forestry.api.apiculture.IBee;
-import forestry.api.genetics.EnumTolerance;
-import forestry.api.genetics.IIndividual;
-import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlText;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.geometry.TextJustification;
+import binnie.core.genetics.Tolerance;
+import forestry.api.apiculture.EnumBeeChromosome;
+import forestry.api.apiculture.IBee;
+import forestry.api.core.EnumHumidity;
+import forestry.api.core.EnumTemperature;
+import forestry.api.genetics.EnumTolerance;
+import forestry.api.genetics.IAlleleTolerance;
+import forestry.api.genetics.IIndividual;
+import forestry.api.lepidopterology.EnumButterflyChromosome;
+import forestry.api.lepidopterology.IButterfly;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.common.BiomeDictionary;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AnalystPageClimate extends ControlAnalystPage
 {
@@ -49,7 +51,7 @@ public class AnalystPageClimate extends ControlAnalystPage
 			humidTol = ((IAlleleTolerance) ind.getGenome().getActiveAllele(EnumButterflyChromosome.HUMIDITY_TOLERANCE)).getValue();
 		}
 		int y = 4;
-		new ControlTextCentered(this, y, "§nClimate").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Climate").setColor(this.getColor());
 		y += 16;
 		new ControlText(this, new IArea(4.0f, y, this.w() - 8.0f, 14.0f), "Temp. Tolerance", TextJustification.MiddleCenter).setColor(this.getColor());
 		y += 12;

--- a/src/main/java/binnie/genetics/gui/AnalystPageDatabase.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageDatabase.java
@@ -4,27 +4,29 @@
 
 package binnie.genetics.gui;
 
-import binnie.core.craftgui.geometry.IPoint;
-import binnie.core.craftgui.events.EventMouse;
-import forestry.api.genetics.IIndividual;
-import binnie.core.craftgui.controls.scroll.ControlScrollBar;
-import binnie.core.craftgui.geometry.TextJustification;
+import binnie.core.craftgui.CraftGUI;
+import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.controls.ControlTextEdit;
 import binnie.core.craftgui.controls.core.Control;
 import binnie.core.craftgui.controls.listbox.ControlListBox;
-import forestry.api.arboriculture.EnumTreeChromosome;
-import binnie.core.craftgui.window.Panel;
+import binnie.core.craftgui.controls.scroll.ControlScrollBar;
+import binnie.core.craftgui.controls.scroll.ControlScrollableContent;
+import binnie.core.craftgui.events.EventMouse;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.geometry.TextJustification;
 import binnie.core.craftgui.minecraft.MinecraftGUI;
 import binnie.core.craftgui.resource.minecraft.CraftGUITexture;
-import binnie.core.craftgui.CraftGUI;
-import java.util.Collection;
-import forestry.api.genetics.IAlleleSpecies;
-import java.util.ArrayList;
-import binnie.core.craftgui.controls.ControlTextEdit;
-import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.window.Panel;
 import binnie.core.genetics.BreedingSystem;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.IWidget;
-import binnie.core.craftgui.controls.scroll.ControlScrollableContent;
+import forestry.api.arboriculture.EnumTreeChromosome;
+import forestry.api.genetics.IAlleleSpecies;
+import forestry.api.genetics.IIndividual;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class AnalystPageDatabase extends ControlAnalystPage
 {
@@ -47,7 +49,7 @@ public class AnalystPageDatabase extends ControlAnalystPage
 		final int newColour = (int) (cr * brightness) * 65536 + (int) (cg * brightness) * 256 + (int) (cb * brightness);
 		this.setColor(newColour);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nRegistry").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Registry").setColor(this.getColor());
 		y += 16;
 		new ControlTextEdit(this, 20.0f, y, this.w() - 40.0f, 16.0f) {
 			@Override

--- a/src/main/java/binnie/genetics/gui/AnalystPageDescription.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageDescription.java
@@ -4,15 +4,16 @@
 
 package binnie.genetics.gui;
 
-import forestry.api.genetics.IAlleleSpecies;
-import binnie.core.craftgui.geometry.IPoint;
-import binnie.core.craftgui.controls.ControlText;
-import binnie.core.craftgui.geometry.TextJustification;
 import binnie.core.craftgui.CraftGUI;
-import binnie.core.craftgui.controls.ControlTextCentered;
-import forestry.api.genetics.IIndividual;
-import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlText;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.geometry.TextJustification;
+import forestry.api.genetics.IAlleleSpecies;
+import forestry.api.genetics.IIndividual;
+import net.minecraft.util.EnumChatFormatting;
 
 public class AnalystPageDescription extends ControlAnalystPage
 {
@@ -24,16 +25,16 @@ public class AnalystPageDescription extends ControlAnalystPage
 		final String branchBinomial = (species.getBranch() != null) ? species.getBranch().getScientific() : "<Unknown>";
 		final String branchName = (species.getBranch() != null) ? species.getBranch().getName() : "Unknown";
 		final String desc = species.getDescription();
-		String descBody = "§o";
+		String descBody = EnumChatFormatting.ITALIC.toString();
 		String descSig = "";
-		if (desc == null || desc == "" || desc.contains("for.description")) {
+		if (desc == null || desc.equals("") || desc.contains("for.description")) {
 			descBody += "";
 		}
 		else {
 			final String[] descStrings = desc.split("\\|");
 			descBody += descStrings[0];
 			for (int i = 1; i < descStrings.length - 1; ++i) {
-				descBody = descBody + " " + descStrings[i];
+				descBody += " " + descStrings[i];
 			}
 			if (descStrings.length > 1) {
 				descSig += descStrings[descStrings.length - 1];
@@ -41,26 +42,26 @@ public class AnalystPageDescription extends ControlAnalystPage
 		}
 		String authority = species.getAuthority();
 		if (authority.contains("Binnie")) {
-			authority = "§1§l" + authority;
+			authority = EnumChatFormatting.DARK_BLUE.toString() + EnumChatFormatting.BOLD + authority;
 		}
 		if (authority.contains("Sengir")) {
-			authority = "§2§l" + authority;
+			authority = EnumChatFormatting.DARK_GREEN.toString() + EnumChatFormatting.BOLD  + authority;
 		}
 		if (authority.contains("MysteriousAges")) {
-			authority = "§5§l" + authority;
+			authority = EnumChatFormatting.DARK_PURPLE.toString() + EnumChatFormatting.BOLD  + authority;
 		}
-		new ControlTextCentered(this, y, "§nDescription").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Description").setColor(this.getColor());
 		y += 16;
-		new ControlTextCentered(this, y, species.getName() + "§r").setColor(this.getColor());
+		new ControlTextCentered(this, y, species.getName() + EnumChatFormatting.RESET).setColor(this.getColor());
 		y += 10;
-		new ControlTextCentered(this, y, "§o" + branchBinomial + " " + species.getBinomial() + "§r").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + branchBinomial + " " + species.getBinomial() + EnumChatFormatting.RESET).setColor(this.getColor());
 		y += 20;
-		new ControlTextCentered(this, y, "Discovered by §l" + authority + "§r").setColor(this.getColor());
-		y += (int) (3.0f + CraftGUI.Render.textHeight("Discovered by §l" + authority + "§r", this.w()));
+		new ControlTextCentered(this, y, "Discovered by " + EnumChatFormatting.BOLD + authority + EnumChatFormatting.RESET).setColor(this.getColor());
+		y += (int) (3.0f + CraftGUI.Render.textHeight("Discovered by " + EnumChatFormatting.BOLD + authority + EnumChatFormatting.RESET, this.w()));
 		new ControlTextCentered(this, y, "Genetic Complexity: " + species.getComplexity()).setColor(this.getColor());
 		y += 26;
-		final ControlText descText = new ControlText(this, new IArea(8.0f, y, this.w() - 16.0f, 0.0f), descBody + "§r", TextJustification.TopCenter);
-		final IWidget signatureText = new ControlText(this, new IArea(8.0f, y, this.w() - 16.0f, 0.0f), descSig + "§r", TextJustification.BottomRight);
+		final ControlText descText = new ControlText(this, new IArea(8.0f, y, this.w() - 16.0f, 0.0f), descBody + EnumChatFormatting.RESET, TextJustification.TopCenter);
+		final IWidget signatureText = new ControlText(this, new IArea(8.0f, y, this.w() - 16.0f, 0.0f), descSig + EnumChatFormatting.RESET, TextJustification.BottomRight);
 		descText.setColor(this.getColor());
 		signatureText.setColor(this.getColor());
 		final float descHeight = CraftGUI.Render.textHeight(descText.getValue(), descText.getSize().x());

--- a/src/main/java/binnie/genetics/gui/AnalystPageDescription.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageDescription.java
@@ -27,7 +27,7 @@ public class AnalystPageDescription extends ControlAnalystPage
 		final String desc = species.getDescription();
 		String descBody = EnumChatFormatting.ITALIC.toString();
 		String descSig = "";
-		if (desc == null || desc.equals("") || desc.contains("for.description")) {
+		if (desc == null || desc.isEmpty() || desc.contains("for.description")) {
 			descBody += "";
 		}
 		else {

--- a/src/main/java/binnie/genetics/gui/AnalystPageFruit.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageFruit.java
@@ -4,24 +4,26 @@
 
 package binnie.genetics.gui;
 
-import java.lang.reflect.Field;
-import forestry.api.arboriculture.ITreeGenome;
+import binnie.Binnie;
+import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IPoint;
-import net.minecraft.init.Items;
-import forestry.api.arboriculture.IAlleleFruit;
-import forestry.api.genetics.IFruitFamily;
-import forestry.api.genetics.IAllele;
-import java.util.Collection;
 import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
-import net.minecraft.item.ItemStack;
-import forestry.arboriculture.FruitProviderPod;
 import binnie.core.util.UniqueItemStackSet;
 import forestry.api.arboriculture.EnumTreeChromosome;
-import binnie.Binnie;
-import binnie.core.craftgui.controls.ControlTextCentered;
+import forestry.api.arboriculture.IAlleleFruit;
 import forestry.api.arboriculture.ITree;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.IWidget;
+import forestry.api.arboriculture.ITreeGenome;
+import forestry.api.genetics.IAllele;
+import forestry.api.genetics.IFruitFamily;
+import forestry.arboriculture.FruitProviderPod;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
 
 public class AnalystPageFruit extends AnalystPageProduce
 {
@@ -30,9 +32,9 @@ public class AnalystPageFruit extends AnalystPageProduce
 		this.setColor(13382400);
 		final ITreeGenome genome = ind.getGenome();
 		int y = 4;
-		new ControlTextCentered(this, y, "§nFruit").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Fruit").setColor(this.getColor());
 		y += 12;
-		new ControlTextCentered(this, y, "§oYield: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.YIELD, ind.getGenome().getActiveAllele(EnumTreeChromosome.YIELD))).setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Yield: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.YIELD, ind.getGenome().getActiveAllele(EnumTreeChromosome.YIELD))).setColor(this.getColor());
 		y += 20;
 		final Collection<ItemStack> products = new UniqueItemStackSet();
 		final Collection<ItemStack> specialties = new UniqueItemStackSet();
@@ -128,7 +130,7 @@ public class AnalystPageFruit extends AnalystPageProduce
 					}
 				}
 			}
-			y = this.getRefined("§o" + fam.getName(), y, stacks);
+			y = this.getRefined(EnumChatFormatting.ITALIC + fam.getName(), y, stacks);
 			y += 2;
 		}
 		this.setSize(new IPoint(this.w(), y + 8));

--- a/src/main/java/binnie/genetics/gui/AnalystPageGenome.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageGenome.java
@@ -12,6 +12,7 @@ import binnie.core.craftgui.controls.ControlText;
 import binnie.core.craftgui.geometry.TextJustification;
 import binnie.core.craftgui.CraftGUI;
 import forestry.api.genetics.IChromosomeType;
+import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.opengl.GL11;
 import binnie.core.craftgui.controls.core.Control;
 import binnie.Binnie;
@@ -30,7 +31,7 @@ public class AnalystPageGenome extends ControlAnalystPage
 		this.active = active;
 		this.setColor(26265);
 		int y = 4;
-		new ControlTextCentered(this, y, "§n" + this.getTitle()).setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + this.getTitle()).setColor(this.getColor());
 		y += 16;
 		final ISpeciesRoot root = AlleleManager.alleleRegistry.getSpeciesRoot(ind.getClass());
 		final BreedingSystem system = Binnie.Genetics.getSystem(root);

--- a/src/main/java/binnie/genetics/gui/AnalystPageGrowth.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageGrowth.java
@@ -12,6 +12,7 @@ import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.genetics.IIndividual;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import net.minecraft.util.EnumChatFormatting;
 
 public class AnalystPageGrowth extends ControlAnalystPage
 {
@@ -20,25 +21,25 @@ public class AnalystPageGrowth extends ControlAnalystPage
 		this.setColor(3355443);
 		int y = 4;
 		final IAlleleSpecies species = ind.getGenome().getPrimary();
-		new ControlTextCentered(this, y, "§nGrowth").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Growth").setColor(this.getColor());
 		y += 12;
 		if (ind instanceof ITree) {
 			final ITree tree = (ITree) ind;
 			final int mat = tree.getGenome().getMaturationTime();
 			new ControlTextCentered(this, y, "Saplings mature in").setColor(this.getColor());
 			y += 12;
-			new ControlTextCentered(this, y, "§l" + this.getTimeString(1373.3999f * mat)).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.BOLD + this.getTimeString(1373.3999f * mat)).setColor(this.getColor());
 			y += 22;
-			new ControlTextCentered(this, y, "§oHeight: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.HEIGHT, ind.getGenome().getActiveAllele(EnumTreeChromosome.HEIGHT))).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Height: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.HEIGHT, ind.getGenome().getActiveAllele(EnumTreeChromosome.HEIGHT))).setColor(this.getColor());
 			y += 12;
-			new ControlTextCentered(this, y, "§oGirth: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.GIRTH, ind.getGenome().getActiveAllele(EnumTreeChromosome.GIRTH))).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Girth: " + Binnie.Genetics.treeBreedingSystem.getAlleleName(EnumTreeChromosome.GIRTH, ind.getGenome().getActiveAllele(EnumTreeChromosome.GIRTH))).setColor(this.getColor());
 			y += 20;
 			new ControlTextCentered(this, y, "Growth Conditions").setColor(this.getColor());
 			y += 12;
-			new ControlTextCentered(this, y, "§o" + tree.getGenome().getGrowthProvider().getDescription()).setColor(this.getColor());
+			new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + tree.getGenome().getGrowthProvider().getDescription()).setColor(this.getColor());
 			y += 12;
 			for (final String s : tree.getGenome().getGrowthProvider().getInfo()) {
-				new ControlTextCentered(this, y, "§o" + s).setColor(this.getColor());
+				new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + s).setColor(this.getColor());
 				y += 12;
 			}
 		}

--- a/src/main/java/binnie/genetics/gui/AnalystPageKaryogram.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageKaryogram.java
@@ -13,6 +13,7 @@ import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.genetics.IIndividual;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import net.minecraft.util.EnumChatFormatting;
 
 public class AnalystPageKaryogram extends ControlAnalystPage
 {
@@ -20,7 +21,7 @@ public class AnalystPageKaryogram extends ControlAnalystPage
 		super(parent, area);
 		this.setColor(10040319);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nKaryogram").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Karyogram").setColor(this.getColor());
 		y += 16;
 		y += 8;
 		final ISpeciesRoot root = AlleleManager.alleleRegistry.getSpeciesRoot(ind.getClass());

--- a/src/main/java/binnie/genetics/gui/AnalystPageMutations.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageMutations.java
@@ -4,33 +4,35 @@
 
 package binnie.genetics.gui;
 
-import binnie.core.craftgui.geometry.TextJustification;
-import binnie.core.craftgui.WidgetAttribute;
-import binnie.core.craftgui.minecraft.EnumColor;
-import java.util.Collection;
-import java.util.List;
-import forestry.api.genetics.IAllele;
-import binnie.genetics.item.ModuleItem;
-import binnie.core.craftgui.geometry.IPoint;
-import binnie.core.craftgui.CraftGUI;
-import forestry.api.genetics.IAlleleSpecies;
-import binnie.core.genetics.BreedingSystem;
-import binnie.core.craftgui.controls.core.Control;
-import forestry.api.genetics.IMutation;
-import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
-import net.minecraft.init.Blocks;
+import binnie.Binnie;
 import binnie.core.Mods;
+import binnie.core.craftgui.CraftGUI;
+import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.WidgetAttribute;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.controls.core.Control;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.geometry.TextJustification;
+import binnie.core.craftgui.minecraft.EnumColor;
+import binnie.core.craftgui.minecraft.Window;
+import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
+import binnie.core.genetics.BreedingSystem;
 import binnie.core.genetics.ForestryAllele;
-import net.minecraft.item.ItemStack;
 import binnie.extrabees.ExtraBees;
 import binnie.extrabees.genetics.ExtraBeesSpecies;
+import binnie.genetics.item.ModuleItem;
 import forestry.api.apiculture.IBee;
-import binnie.core.craftgui.minecraft.Window;
-import binnie.Binnie;
-import binnie.core.craftgui.controls.ControlTextCentered;
+import forestry.api.genetics.IAllele;
+import forestry.api.genetics.IAlleleSpecies;
 import forestry.api.genetics.IIndividual;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.IWidget;
+import forestry.api.genetics.IMutation;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.Collection;
+import java.util.List;
 
 public class AnalystPageMutations extends ControlAnalystPage
 {
@@ -38,7 +40,7 @@ public class AnalystPageMutations extends ControlAnalystPage
 		super(parent, area);
 		this.setColor(3355392);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nMutations").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Mutations").setColor(this.getColor());
 		y += 18;
 		final BreedingSystem system = Binnie.Genetics.getSystem(ind.getGenome().getSpeciesRoot());
 		final List<IMutation> discovered = system.getDiscoveredMutations(Window.get(this).getWorld(), Window.get(this).getUsername());
@@ -83,13 +85,13 @@ public class AnalystPageMutations extends ControlAnalystPage
 			if (ind.getGenome().getPrimary() == ForestryAllele.BeeSpecies.Valiant.getAllele()) {
 				new ControlTextCentered(this, y, "Natural Habitat").setColor(this.getColor());
 				y += 10;
-				new ControlTextCentered(this, y, "§oFound in any Hive").setColor(this.getColor());
+				new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Found in any Hive").setColor(this.getColor());
 				y += 22;
 			}
 			else if (ind.getGenome().getPrimary() == ForestryAllele.BeeSpecies.Monastic.getAllele()) {
 				new ControlTextCentered(this, y, "Natural Habitat").setColor(this.getColor());
 				y += 10;
-				new ControlTextCentered(this, y, "§oBought from Villagers").setColor(this.getColor());
+				new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Bought from Villagers").setColor(this.getColor());
 				y += 22;
 			}
 			else if (hive != null) {

--- a/src/main/java/binnie/genetics/gui/AnalystPageProducts.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageProducts.java
@@ -4,31 +4,33 @@
 
 package binnie.genetics.gui;
 
-import binnie.core.craftgui.controls.ControlText;
-import forestry.plugins.PluginApiculture;
-import binnie.core.craftgui.geometry.CraftGUIUtil;
-import net.minecraft.nbt.NBTTagCompound;
+import binnie.Binnie;
+import binnie.core.BinnieCore;
+import binnie.core.craftgui.IWidget;
 import binnie.core.craftgui.Tooltip;
-import forestry.api.apiculture.IBeeGenome;
+import binnie.core.craftgui.controls.ControlText;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.CraftGUIUtil;
+import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IPoint;
-import binnie.extratrees.craftgui.kitchen.ControlFluidDisplay;
-import net.minecraft.init.Items;
-import net.minecraftforge.fluids.FluidContainerRegistry;
 import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
+import binnie.core.util.UniqueItemStackSet;
+import binnie.extratrees.craftgui.kitchen.ControlFluidDisplay;
+import forestry.api.apiculture.EnumBeeChromosome;
+import forestry.api.apiculture.IBee;
+import forestry.api.apiculture.IBeeGenome;
+import forestry.plugins.PluginApiculture;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
-import net.minecraft.item.ItemStack;
 import java.util.HashMap;
-import binnie.core.util.UniqueItemStackSet;
-import forestry.api.apiculture.EnumBeeChromosome;
-import binnie.core.craftgui.controls.ControlTextCentered;
-import binnie.core.BinnieCore;
-import binnie.Binnie;
-import forestry.api.apiculture.IBee;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.IWidget;
+import java.util.Map;
 
 public class AnalystPageProducts extends AnalystPageProduce
 {
@@ -39,9 +41,9 @@ public class AnalystPageProducts extends AnalystPageProduce
 		final float speed = genome.getSpeed();
 		final float modeSpeed = Binnie.Genetics.getBeeRoot().getBeekeepingMode(BinnieCore.proxy.getWorld()).getBeeModifier().getProductionModifier(genome, 1.0f);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nProduce").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Produce").setColor(this.getColor());
 		y += 12;
-		new ControlTextCentered(this, y, "§oRate: " + Binnie.Genetics.beeBreedingSystem.getAlleleName(EnumBeeChromosome.SPEED, ind.getGenome().getActiveAllele(EnumBeeChromosome.SPEED))).setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.ITALIC + "Rate: " + Binnie.Genetics.beeBreedingSystem.getAlleleName(EnumBeeChromosome.SPEED, ind.getGenome().getActiveAllele(EnumBeeChromosome.SPEED))).setColor(this.getColor());
 		y += 20;
 		final Collection<ItemStack> refinedProducts = new UniqueItemStackSet();
 		final Collection<ItemStack> productList = new UniqueItemStackSet();

--- a/src/main/java/binnie/genetics/gui/AnalystPageSoil.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageSoil.java
@@ -5,23 +5,25 @@
 package binnie.genetics.gui;
 
 import binnie.Binnie;
-import java.util.List;
-import forestry.api.genetics.EnumTolerance;
-import java.util.EnumSet;
-import java.util.ArrayList;
-import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
-import net.minecraft.item.ItemStack;
-import binnie.botany.gardening.BlockSoil;
 import binnie.botany.Botany;
 import binnie.botany.api.EnumAcidity;
-import binnie.core.genetics.Tolerance;
 import binnie.botany.api.EnumMoisture;
-import binnie.core.craftgui.controls.ControlText;
-import binnie.core.craftgui.geometry.TextJustification;
-import binnie.core.craftgui.controls.ControlTextCentered;
 import binnie.botany.api.IFlower;
-import binnie.core.craftgui.geometry.IArea;
+import binnie.botany.gardening.BlockSoil;
 import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlText;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.IArea;
+import binnie.core.craftgui.geometry.TextJustification;
+import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
+import binnie.core.genetics.Tolerance;
+import forestry.api.genetics.EnumTolerance;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
 
 public class AnalystPageSoil extends ControlAnalystPage
 {
@@ -33,7 +35,7 @@ public class AnalystPageSoil extends ControlAnalystPage
 		final EnumAcidity pH = flower.getGenome().getPrimary().getPH();
 		final EnumTolerance pHTol = flower.getGenome().getTolerancePH();
 		int y = 4;
-		new ControlTextCentered(this, y, "§nSoil").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Soil").setColor(this.getColor());
 		y += 16;
 		new ControlText(this, new IArea(4.0f, y, this.w() - 8.0f, 14.0f), "Moisture Tolerance", TextJustification.MiddleCenter).setColor(this.getColor());
 		y += 12;

--- a/src/main/java/binnie/genetics/gui/AnalystPageSpecimen.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageSpecimen.java
@@ -8,6 +8,7 @@ import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.lepidopterology.IButterfly;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.IWidget;
+import net.minecraft.util.EnumChatFormatting;
 
 public class AnalystPageSpecimen extends ControlAnalystPage
 {
@@ -15,7 +16,7 @@ public class AnalystPageSpecimen extends ControlAnalystPage
 		super(parent, area);
 		this.setColor(3355443);
 		int y = 4;
-		new ControlTextCentered(this, y, "§nSpecimen").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Specimen").setColor(this.getColor());
 		y += 12;
 		final float w = (this.w() - 16.0f) * ind.getSize();
 		new ControlIndividualDisplay(this, (this.w() - w) / 2.0f, y + (this.w() - w) / 2.0f, w, ind);

--- a/src/main/java/binnie/genetics/gui/AnalystPageWood.java
+++ b/src/main/java/binnie/genetics/gui/AnalystPageWood.java
@@ -4,27 +4,24 @@
 
 package binnie.genetics.gui;
 
-import forestry.api.arboriculture.ITreeGenome;
+import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.controls.ControlTextCentered;
+import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IPoint;
-
-import java.util.Collection;
-
-import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
-
-import net.minecraft.item.ItemStack;
-
-import net.minecraftforge.common.util.ForgeDirection;
-
-import binnie.core.util.UniqueItemStackSet;
 import binnie.core.craftgui.minecraft.control.ControlIconDisplay;
+import binnie.core.craftgui.minecraft.control.ControlItemDisplay;
+import binnie.core.util.UniqueItemStackSet;
+import binnie.extratrees.FakeWorld;
 import binnie.genetics.item.ModuleItem;
 import forestry.api.arboriculture.EnumTreeChromosome;
-import forestry.api.genetics.IAlleleBoolean;
-import binnie.core.craftgui.controls.ControlTextCentered;
 import forestry.api.arboriculture.ITree;
-import binnie.core.craftgui.geometry.IArea;
-import binnie.core.craftgui.IWidget;
-import binnie.extratrees.FakeWorld;
+import forestry.api.arboriculture.ITreeGenome;
+import forestry.api.genetics.IAlleleBoolean;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.Collection;
 
 public class AnalystPageWood extends AnalystPageProduce
 {
@@ -33,7 +30,7 @@ public class AnalystPageWood extends AnalystPageProduce
 		this.setColor(6697728);
 		final ITreeGenome genome = ind.getGenome();
 		int y = 4;
-		new ControlTextCentered(this, y, "§nWood").setColor(this.getColor());
+		new ControlTextCentered(this, y, EnumChatFormatting.UNDERLINE + "Wood").setColor(this.getColor());
 		y += 12;
 		if (((IAlleleBoolean) ind.getGenome().getActiveAllele(EnumTreeChromosome.FIREPROOF)).getValue()) {
 			new ControlIconDisplay(this, (this.w() - 16.0f) / 2.0f, y, ModuleItem.iconNoFire.getIcon()).addTooltip("Fireproof");

--- a/src/main/java/binnie/genetics/gui/ControlToleranceBar.java
+++ b/src/main/java/binnie/genetics/gui/ControlToleranceBar.java
@@ -4,18 +4,20 @@
 
 package binnie.genetics.gui;
 
-import binnie.core.genetics.Tolerance;
-import forestry.api.genetics.EnumTolerance;
+import binnie.core.craftgui.CraftGUI;
+import binnie.core.craftgui.ITooltip;
+import binnie.core.craftgui.IWidget;
+import binnie.core.craftgui.Tooltip;
+import binnie.core.craftgui.WidgetAttribute;
+import binnie.core.craftgui.controls.core.Control;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IBorder;
-import binnie.core.craftgui.CraftGUI;
-import binnie.core.craftgui.Tooltip;
+import binnie.core.genetics.Tolerance;
 import forestry.api.core.EnumTemperature;
-import binnie.core.craftgui.WidgetAttribute;
-import binnie.core.craftgui.IWidget;
+import forestry.api.genetics.EnumTolerance;
+import net.minecraft.util.EnumChatFormatting;
+
 import java.util.EnumSet;
-import binnie.core.craftgui.ITooltip;
-import binnie.core.craftgui.controls.core.Control;
 
 public abstract class ControlToleranceBar<T extends Enum<T>> extends Control implements ITooltip
 {
@@ -40,7 +42,7 @@ public abstract class ControlToleranceBar<T extends Enum<T>> extends Control imp
 		final int type = (int) ((int) this.getRelativeMousePosition().x() / (this.getSize().x() / types));
 		for (final T tol : this.fullSet) {
 			if (tol.ordinal() - ((this.enumClass == EnumTemperature.class) ? 1 : 0) == type) {
-				tooltip.add((this.tolerated.contains(tol) ? "" : "§8") + this.getName(tol));
+				tooltip.add((this.tolerated.contains(tol) ? "" : EnumChatFormatting.DARK_GRAY) + this.getName(tol));
 			}
 		}
 	}


### PR DESCRIPTION
Fix issue #22 
Text colors were wrapped to EnumChatFormatting, because "§" char was displayed as "B" char in all tooltips.
I think this is decompile bug.