### PR TITLE
Fix the generation of Hives #274

### DIFF
--- a/extrabees/src/main/java/binnie/extrabees/utils/config/ConfigurationMain.java
+++ b/extrabees/src/main/java/binnie/extrabees/utils/config/ConfigurationMain.java
@@ -6,7 +6,7 @@ public class ConfigurationMain implements IConfigurable {
 
 	private static final String WORLDGEN = "World-Gen";
 	public static boolean canQuarryMineHives = true;
-	public static int waterHiveRate = 1;
+	public static int waterHiveRate = 2;
 	public static int rockHiveRate = 2;
 	public static int netherHiveRate = 2;
 	public static int marbleHiveRate = 2;

--- a/extrabees/src/main/java/binnie/extrabees/worldgen/WorldGenHiveMarble.java
+++ b/extrabees/src/main/java/binnie/extrabees/worldgen/WorldGenHiveMarble.java
@@ -31,19 +31,18 @@ public class WorldGenHiveMarble extends WorldGenHive {
 			return false;
 		}
 
-		//generate when one face is different from marble
+		//generate when at least two faces are different from marble
 		int otherFace = 0;
 		for (EnumFacing face : EnumFacing.values()) {
 			if (!world.getBlockState(position.offset(face)).getBlock().equals(blockAtPos)) {
 				otherFace++;
 				if (otherFace > 1) {
+					world.setBlockState(position, ExtraBees.hive.getDefaultState().withProperty(BlockExtraBeeHives.HIVE_TYPE, EnumHiveType.MARBLE));
 					return true;
 				}
 			}
 		}
 
-		world.setBlockState(position, ExtraBees.hive.getDefaultState().withProperty(BlockExtraBeeHives.HIVE_TYPE, EnumHiveType.MARBLE));
-
-		return true;
+		return false;
 	}
 }

--- a/extrabees/src/main/java/binnie/extrabees/worldgen/WorldGenHiveRock.java
+++ b/extrabees/src/main/java/binnie/extrabees/worldgen/WorldGenHiveRock.java
@@ -21,12 +21,13 @@ public class WorldGenHiveRock extends WorldGenHive {
 	@Override
 	public boolean generate(final World world, final Random random, final BlockPos pos) {
 		final IBlockState block = world.getBlockState(pos);
-		if (!block.getBlock().isAir(block, world, pos)) {
-			return true;
+		if (block.getBlock().isAir(block, world, pos)) {
+			return false;
 		}
 		if (block.getBlock().isReplaceableOreGen(block, world, pos, BlockStateMatcher.forBlock(Blocks.STONE))) {
 			world.setBlockState(pos, ExtraBees.hive.getDefaultState().withProperty(BlockExtraBeeHives.HIVE_TYPE, EnumHiveType.ROCK));
+			return true;
 		}
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
Fixes the conditions when or when not to generate a rocky or marble hive.

regarding the generation of Marble Hives:
I think marble was generating before but *very* rare depending on how marble veins are generated.
If no mods are installed that provide stoneMarble (oredict) then Marble Hives won't generate anyway.

Until now (before this commit / PR) Marble Hives genreated like this:
1. abort if the randomly selected block is not in the list of allowed blocks (currently oredict stoneMarble <- mods like chisel add marble, vanilla MC + forestry + binnies by itself don't include a stoneMarble block)
2. abort if more than one of the 6 adjacent blocks is different from the block itself
3. generate Marble Hive
(so at least 5 adjacent blocks have to be the same marble block in order to generate a hive)

With this PR marble genreates like this:
1. (same as before) abort if the randomly selected block is not in the list of allowed blocks
2. if more than one (at least two) of the 6 adjacent blocks is different from the block itself generate the Hive

| # of adjacent marble blocks (same block) | before | after |
| ---:| --- | --- |
| 0 | ✘ | ✔ |
| 1 | ✘ | ✔ |
| 2 | ✘ | ✔ |
| 3 | ✘ | ✔ |
| 4 | ✘ | ✔ |
| 5 | ✔ | ✘ |
| 6 | ✔ | ✘ |

Maybe my change to the marble hive generation doesn't make much sense or should be done differently. It's just that to me the logic behind the generation like it was before felt wrong.

The fix to rocky hive generation however seems necessary in one way or another.