### PR TITLE
Fix IndexOutOfBoundsException

### DIFF
--- a/botany/src/main/java/binnie/botany/blocks/BlockSoil.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockSoil.java
@@ -67,7 +67,9 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 	}
 
 	public static String getPH(ItemStack stack, boolean withColor, boolean byNeutralNone) {
-		EnumAcidity ph = EnumAcidity.values()[stack.getItemDamage() / 3];
+		int index = stack.getItemDamage() / 3;
+		index = (index < EnumAcidity.values().length) ? index : EnumAcidity.values().length - 1;
+		EnumAcidity ph = EnumAcidity.values()[index];
 		if (byNeutralNone) {
 			if (ph == EnumAcidity.NEUTRAL) {
 				return "";


### PR DESCRIPTION
Fix IndexOutOfBoundsException on getPH() if passed itemstack's damage value is 9 or larger, which could happen via /give.

New behavior: instead of throwing an exception if the damage value is 9 or larger, it will use the last value in EnumAcidity.values(), which is currently ALKALINE.