### PR TITLE
Fix Ceramic Brick pick block

### DIFF
--- a/botany/src/main/java/binnie/botany/blocks/BlockCeramicBrick.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockCeramicBrick.java
@@ -186,7 +186,7 @@ public class BlockCeramicBrick extends Block implements IMultipassBlock<CeramicB
 	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
 		TileCeramicBrick ceramic = TileUtil.getTile(world, pos, TileCeramicBrick.class);
 		if (ceramic != null) {
-			return ceramic.pair().getStack(0);
+			return ceramic.pair().getStack(1);
 		}
 		return super.getPickBlock(state, target, world, pos, player);
 	}


### PR DESCRIPTION
This fixes Ceramic Bricks not giving a block when middle-clicked. Also makes the bricks show up correctly in The One Probe.