### PR TITLE
Validate ItemFieldKit to avoid metadata manipulations with items

### DIFF
--- a/src/main/java/binnie/core/craftgui/WindowFieldKit.java
+++ b/src/main/java/binnie/core/craftgui/WindowFieldKit.java
@@ -213,6 +213,10 @@ public class WindowFieldKit extends Window {
 		super.onWindowInventoryChanged();
 		if (isServer()) {
 			ItemStack kit = getPlayer().getHeldItem();
+			if(kit == null || !kit.getItem().equals(BinnieCore.fieldKit)) {
+				return;
+			}
+
 			int sheets = 64 - kit.getItemDamage();
 			int size = (getWindowInventory().getStackInSlot(1) == null) ? 0 : getWindowInventory().getStackInSlot(1).stackSize;
 			if (sheets != size) {


### PR DESCRIPTION
Validate ItemFieldKit to avoid metadata manipulations with items, putted in held slot alongside GUI FieldKit are opened.

This is unfinished fix, held slot should be locked from manipulations like Forestry do it (look into backpack code, e.g).

Problem source: https://www.youtube.com/watch?v=P0vVA5hMGSM