### PR TITLE
Fix incorrent "No space in Tank" when making enzymes

### DIFF
--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipe.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipe.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 import java.util.Random;
 
 import binnie.core.machines.transfer.TransferResult;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import net.minecraftforge.fluids.FluidStack;

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipe.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipe.java
@@ -116,7 +116,7 @@ public class IncubatorRecipe implements IIncubatorRecipe {
 			final ItemStack output = outputStack.copy();
 			final TransferRequest product = new TransferRequest(output, machine.getInventory()).setTargetSlots(Incubator.SLOT_OUTPUT).ignoreValidation();
 			TransferResult transferResult = product.transfer(null, false);
-			return transferResult.isSuccess() && transferResult.getRemaining().isEmpty();
+			return transferResult.isSuccess() && (transferResult.getRemaining().isEmpty() || transferResult.getRemaining().get(0).getItem() == Items.AIR);
 		}
 		return true;
 	}


### PR DESCRIPTION
Fixes https://github.com/ForestryMC/Binnie/issues/391

transferResult.getRemaining() returns with an Item of Air. This is more or less a fast hack as the bug is probably in TransferRequest#transfer