### PR TITLE
Fixing warning at startup, like:

### DIFF
--- a/core/src/main/resources/assets/binniecore/models/block/machine.json
+++ b/core/src/main/resources/assets/binniecore/models/block/machine.json
@@ -1,8 +1,5 @@
 {
 	"parent": "block/block",
-	"textures":{
-		"particle": "#texture"
-	},
 	"elements": [
 		{
 			"__comment": "base_back",


### PR DESCRIPTION
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`
`[18:53:56] [main/WARN]: Unable to resolve texture due to upward reference: #texture in binniecore:models/block/machine.json`