### PR TITLE
Fixing invalid (dublicate) hammer registration.

### DIFF
--- a/extratrees/src/main/java/binnie/extratrees/items/ExtraTreeItems.java
+++ b/extratrees/src/main/java/binnie/extratrees/items/ExtraTreeItems.java
@@ -12,7 +12,6 @@ import binnie.core.util.I18N;
 import binnie.extratrees.modules.ModuleCore;
 
 public enum ExtraTreeItems implements IItemMiscProvider {
-	CARPENTRY_HAMMER("carpentry_hammer"),
 	SAWDUST("sawdust"),
 	Bark("bark"),
 	PROVEN_GEAR("proven_gear"),
@@ -49,7 +48,7 @@ public enum ExtraTreeItems implements IItemMiscProvider {
 
 	@Override
 	public boolean isActive() {
-		return this != ExtraTreeItems.CARPENTRY_HAMMER;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Hammers are registered twice.
`binnie/extratrees/modules/ModuleCore.java`
Once explicitly (through instance creation).
```
itemHammer = new ItemHammer(false);
ExtraTrees.proxy.registerItem(itemHammer);
itemDurableHammer = new ItemHammer(true);
ExtraTrees.proxy.registerItem(itemDurableHammer);
```
The second time implicitly through adding an item to the `itemMisc`, afterwards through the game tries to load the json model from the `misc` folder, which is incorrect.
```
itemMisc = new ItemMisc(Tabs.tabArboriculture, ExtraTreeItems.values());
ExtraTrees.proxy.registerItem(itemMisc);
```