### PR TITLE
Messages about the error-deprecated method are suppressed in core/src/main/java/binnie/core/machines/BlockMachine.java.

### DIFF
--- a/core/src/main/java/binnie/core/machines/BlockMachine.java
+++ b/core/src/main/java/binnie/core/machines/BlockMachine.java
@@ -59,16 +59,19 @@ class BlockMachine extends Block implements IBlockMachine, ITileEntityProvider {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public EnumBlockRenderType getRenderType(IBlockState state) {
 		return EnumBlockRenderType.MODEL;
 	}
@@ -84,6 +87,7 @@ class BlockMachine extends Block implements IBlockMachine, ITileEntityProvider {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(MACHINE_TYPE, meta);
 	}


### PR DESCRIPTION
I want to update the code to remove all possible errors and warnings.
Decided to fix deprecated methods.
As indicated,
including in this topic,
http://www.minecraftforge.net/forum/topic/39491-194-deprecated-methods-in-blocks/
these messages can be easily suppressed.