### PR TITLE
Suppress warnings deprecation

### DIFF
--- a/botany/src/main/java/binnie/botany/GardeningManager.java
+++ b/botany/src/main/java/binnie/botany/GardeningManager.java
@@ -18,7 +18,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
-import forestry.api.climate.IClimateInfo;
+import forestry.api.climate.IClimateState;
 import forestry.api.core.EnumTemperature;
 import forestry.api.core.ForestryAPI;
 
@@ -101,7 +101,7 @@ public class GardeningManager implements IGardeningManager {
 
 	@Override
 	public float getBiomeMoisture(World world, BlockPos pos) {
-		IClimateInfo info = ForestryAPI.climateManager.getInfo(world, pos);
+		IClimateState info = ForestryAPI.climateManager.getClimateState(world, pos);
 		double humidity = info.getHumidity();
 		double temperature = info.getTemperature();
 		double moisture = 3.2 * (humidity - 0.5) - 0.4 * (1.0 + temperature + 0.5 * temperature * temperature) + 1.1 - 1.6 * (temperature - 0.9) * (temperature - 0.9) - 0.002 * (pos.getY() - 64);
@@ -110,7 +110,7 @@ public class GardeningManager implements IGardeningManager {
 
 	@Override
 	public float getBiomePH(World world, BlockPos pos) {
-		IClimateInfo info = ForestryAPI.climateManager.getInfo(world, pos);
+		IClimateState info = ForestryAPI.climateManager.getClimateState(world, pos);
 		double humidity = info.getHumidity();
 		double temperature = info.getTemperature();
 		return (float) (-3.0 * (humidity - 0.5) + 0.5 * (temperature - 0.699999988079071) * (temperature - 0.699999988079071) + 0.02f * (pos.getY() - 64) - 0.15000000596046448);

--- a/botany/src/main/java/binnie/botany/blocks/BlockCeramicBrick.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockCeramicBrick.java
@@ -152,6 +152,7 @@ public class BlockCeramicBrick extends Block implements IMultipassBlock<CeramicB
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(TYPE, CeramicBrickType.VALUES[meta]);
 	}

--- a/botany/src/main/java/binnie/botany/blocks/BlockPlant.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockPlant.java
@@ -67,6 +67,7 @@ public class BlockPlant extends BlockBush implements IItemModelRegister {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(PLANT_TYPE, PlantType.getType(meta));
 	}

--- a/botany/src/main/java/binnie/botany/blocks/BlockSoil.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockSoil.java
@@ -90,6 +90,7 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 
 	@Override
 	@SideOnly(Side.CLIENT)
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		switch (side) {
 			case UP:
@@ -110,11 +111,13 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 	 * Used to determine ambient occlusion and culling when rebuilding chunks for render
 	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -125,17 +128,20 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		return SOIL_BLOCK_AABB;
 	}
 
 	@Nullable
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, IBlockAccess worldIn, BlockPos pos) {
 		return SOIL_BLOCK_AABB;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getSelectedBoundingBox(IBlockState state, World worldIn, BlockPos pos) {
 		return SOIL_BLOCK_AABB;
 	}
@@ -190,6 +196,7 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		EnumMoisture moisture = EnumMoisture.values()[meta % 3];
 		EnumAcidity acidity = EnumAcidity.values()[meta / 3];
@@ -233,6 +240,7 @@ public class BlockSoil extends Block implements IBlockSoil, IItemModelRegister {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
 		super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
 

--- a/botany/src/main/java/binnie/botany/blocks/BlockStainedGlass.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockStainedGlass.java
@@ -56,6 +56,7 @@ public class BlockStainedGlass extends Block implements IBlockMetadata, IColored
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
@@ -76,6 +77,7 @@ public class BlockStainedGlass extends Block implements IBlockMetadata, IColored
 
 	@Override
 	@SideOnly(Side.CLIENT)
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		IBlockState iblockstate = blockAccess.getBlockState(pos.offset(side));
 		Block block = iblockstate.getBlock();
@@ -120,6 +122,7 @@ public class BlockStainedGlass extends Block implements IBlockMetadata, IColored
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean eventReceived(IBlockState state, World worldIn, BlockPos pos, int id, int param) {
 		TileEntity tileentity = worldIn.getTileEntity(pos);
 		return tileentity != null && tileentity.receiveClientEvent(id, param);

--- a/botany/src/main/java/binnie/botany/farming/GardenLogic.java
+++ b/botany/src/main/java/binnie/botany/farming/GardenLogic.java
@@ -145,6 +145,7 @@ public class GardenLogic extends FarmLogic {
 					ItemStack block = getAsItemStack(world, position);
 					ItemStack loam = getAvailableLoam(housing);
 					if (isWaste(block) && !loam.isEmpty()) {
+						@SuppressWarnings("deprecation")
 						IBlockState blockState = Block.getBlockFromItem(block.getItem()).getStateFromMeta(block.getItemDamage());
 						Blocks.DIRT.getDrops(produce, world, position, blockState, 0);
 						setBlock(world, position, Blocks.AIR, 0);

--- a/botany/src/main/java/binnie/botany/genetics/AlleleFlowerColor.java
+++ b/botany/src/main/java/binnie/botany/genetics/AlleleFlowerColor.java
@@ -41,6 +41,7 @@ public class AlleleFlowerColor implements IAlleleFlowerColor {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public String getName() {
 		return name;
 	}

--- a/core/src/main/java/binnie/core/block/BlockMetadata.java
+++ b/core/src/main/java/binnie/core/block/BlockMetadata.java
@@ -39,6 +39,7 @@ public class BlockMetadata extends BlockContainer implements IBlockMetadata {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	public static boolean breakBlock(IBlockMetadata blockMetadata, @Nullable EntityPlayer player, World world, BlockPos pos) {
 		List<ItemStack> drops = new ArrayList<>();
 		Block block = (Block) blockMetadata;

--- a/extratrees/src/main/java/binnie/extratrees/blocks/BlockCarpentryPanel.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/BlockCarpentryPanel.java
@@ -29,6 +29,7 @@ public class BlockCarpentryPanel extends BlockCarpentry {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		final DesignBlock block = this.getCarpentryBlock(source, pos);
 		switch (block.getFacing()) {
@@ -66,11 +67,13 @@ public class BlockCarpentryPanel extends BlockCarpentry {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -103,6 +106,7 @@ public class BlockCarpentryPanel extends BlockCarpentry {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isSideSolid(IBlockState base_state, IBlockAccess world, BlockPos pos, EnumFacing side) {
 		return false;
 	}

--- a/extratrees/src/main/java/binnie/extratrees/blocks/BlockETDecorativeLeaves.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/BlockETDecorativeLeaves.java
@@ -111,17 +111,20 @@ public abstract class BlockETDecorativeLeaves extends Block implements IItemMode
 	 * Used to determine ambient occlusion and culling when rebuilding chunks for render
 	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return !Proxies.render.fancyGraphicsEnabled();
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean causesSuffocation(IBlockState state) {
 		return false;
 	}
 
 	@Override
 	@SideOnly(Side.CLIENT)
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		if (Proxies.render.fancyGraphicsEnabled() || blockAccess.getBlockState(pos.offset(side)).getBlock() != this) {
 			if (super.shouldSideBeRendered(blockState, blockAccess, pos, side)) {
@@ -151,6 +154,7 @@ public abstract class BlockETDecorativeLeaves extends Block implements IItemMode
 	 * Convert the given metadata into a BlockState for this Block
 	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		ETTreeDefinition type = getTreeType(meta);
 		return getDefaultState().withProperty(getVariant(), type);

--- a/extratrees/src/main/java/binnie/extratrees/blocks/BlockHops.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/BlockHops.java
@@ -213,6 +213,7 @@ public class BlockHops extends BlockCrops{
 	}
 	
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getActualState(IBlockState state, IBlockAccess worldIn, BlockPos pos) {
 		if (state.getValue(HALF) == HopsHalf.UP) {
 			IBlockState iblockstate = worldIn.getBlockState(pos.down());

--- a/extratrees/src/main/java/binnie/extratrees/blocks/BlockStainedDesign.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/BlockStainedDesign.java
@@ -75,11 +75,13 @@ public class BlockStainedDesign extends BlockDesign {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -97,6 +99,7 @@ public class BlockStainedDesign extends BlockDesign {
 
 	@Override
 	@SideOnly(Side.CLIENT)
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		IBlockState iblockstate = blockAccess.getBlockState(pos.offset(side));
 		Block block = iblockstate.getBlock();

--- a/extratrees/src/main/java/binnie/extratrees/blocks/decor/BlockHedge.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/decor/BlockHedge.java
@@ -47,6 +47,7 @@ public class BlockHedge extends Block implements IBlockFence, IColoredBlock {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void addCollisionBoxToList(IBlockState state, World world, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean p_185477_7_) {
 		final boolean connectNegZ = this.canConnectFenceTo(world, pos.north());
 		final boolean connectPosZ = this.canConnectFenceTo(world, pos.south());
@@ -86,6 +87,7 @@ public class BlockHedge extends Block implements IBlockFence, IColoredBlock {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess world, BlockPos pos) {
 		final boolean connectNegZ = this.canConnectFenceTo(world, pos.north());
 		final boolean connectPosZ = this.canConnectFenceTo(world, pos.south());
@@ -111,11 +113,13 @@ public class BlockHedge extends Block implements IBlockFence, IColoredBlock {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -157,6 +161,7 @@ public class BlockHedge extends Block implements IBlockFence, IColoredBlock {
 
 	@SideOnly(Side.CLIENT)
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		return true;
 	}

--- a/extratrees/src/main/java/binnie/extratrees/blocks/decor/BlockMultiFence.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/decor/BlockMultiFence.java
@@ -67,6 +67,7 @@ public class BlockMultiFence extends BlockFence implements IBlockMetadata, IStat
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean eventReceived(IBlockState state, World world, BlockPos pos, int id, int param) {
 		TileEntity tileentity = world.getTileEntity(pos);
 		return tileentity != null && tileentity.receiveClientEvent(id, param);

--- a/extratrees/src/main/java/binnie/extratrees/blocks/wood/BlockETDoor.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/wood/BlockETDoor.java
@@ -100,6 +100,7 @@ public class BlockETDoor extends BlockDoor implements IWoodTyped, IItemModelRegi
 	}
 	
 	@Override
+	@SuppressWarnings("deprecation")
 	public float getBlockHardness(IBlockState blockState, World worldIn, BlockPos pos) {
 		int meta = getMetaFromState(blockState);
 		EnumETLog woodType = getWoodType(meta);

--- a/extratrees/src/main/java/binnie/extratrees/blocks/wood/BlockShrubLog.java
+++ b/extratrees/src/main/java/binnie/extratrees/blocks/wood/BlockShrubLog.java
@@ -110,6 +110,7 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean p_185477_7_) {
 		if (!p_185477_7_) {
 			state = state.getActualState(worldIn, pos);
@@ -135,17 +136,20 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		state = this.getActualState(state, source, pos);
 		return BOUNDING_BOXES[getBoundingBoxIdx(state)];
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -157,7 +161,7 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 			return 0;
 		} else if (face == EnumFacing.DOWN) {
 			return 20;
-		} else if (face != EnumFacing.UP) {
+		} else if (face == EnumFacing.UP) {
 			return 10;
 		} else {
 			return 5;
@@ -175,6 +179,7 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 
 	@Override
 	@SideOnly(Side.CLIENT)
+	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos,
 	                                    EnumFacing side) {
 		return true;
@@ -186,11 +191,13 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(FIREPROOF, meta == 1);
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState getActualState(IBlockState state, IBlockAccess worldIn, BlockPos pos) {
 		return state.withProperty(NORTH, canFenceConnectTo(worldIn, pos, EnumFacing.NORTH))
 			.withProperty(EAST, canFenceConnectTo(worldIn, pos, EnumFacing.EAST))
@@ -240,6 +247,7 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState withRotation(IBlockState state, Rotation rot) {
 		switch (rot) {
 			case CLOCKWISE_180:
@@ -257,6 +265,7 @@ public class BlockShrubLog extends Block implements IWoodTyped, IStateMapperRegi
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public IBlockState withMirror(IBlockState state, Mirror mirrorIn) {
 		switch (mirrorIn) {
 			case LEFT_RIGHT:

--- a/extratrees/src/main/java/binnie/extratrees/genetics/AlleleETFruit.java
+++ b/extratrees/src/main/java/binnie/extratrees/genetics/AlleleETFruit.java
@@ -20,6 +20,7 @@ public class AlleleETFruit extends AlleleCategorized implements IAlleleFruit {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public String getName() {
 		return getProvider().getDescription();
 	}


### PR DESCRIPTION
Group of changes to suppress false alerts.
Besides:
1. Updated one method to the more relevant to the forester api.
2. Fixed a bug with the speed of fire propagation for the block BlockShrubLog

I will group such changes, but in not very large batches, it's safer.