### PR TITLE
Add version tag stub.

### DIFF
--- a/botany/src/main/java/binnie/botany/Botany.java
+++ b/botany/src/main/java/binnie/botany/Botany.java
@@ -28,7 +28,7 @@ import binnie.genetics.api.analyst.IAnalystManager;
 @Mod(
 	modid = Constants.BOTANY_MOD_ID,
 	name = "Binnie's Botany",
-    version = "@VERSION@",
+	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 	dependencies = "required-after:" + Constants.CORE_MOD_ID + ";"
 			+	   "after:" + Constants.GENETICS_MOD_ID + ";"

--- a/botany/src/main/java/binnie/botany/Botany.java
+++ b/botany/src/main/java/binnie/botany/Botany.java
@@ -28,6 +28,7 @@ import binnie.genetics.api.analyst.IAnalystManager;
 @Mod(
 	modid = Constants.BOTANY_MOD_ID,
 	name = "Binnie's Botany",
+    version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 	dependencies = "required-after:" + Constants.CORE_MOD_ID + ";"
 			+	   "after:" + Constants.GENETICS_MOD_ID + ";"

--- a/design/src/main/java/binnie/design/Design.java
+++ b/design/src/main/java/binnie/design/Design.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 @Mod(
 		modid = Constants.DESIGN_MOD_ID,
 		name = "Binnie's Design",
+		version = "@VERSION@",
 		acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 		dependencies = "required-after:" + Constants.CORE_MOD_ID + ";"
 )

--- a/extrabees/src/main/java/binnie/extrabees/ExtraBees.java
+++ b/extrabees/src/main/java/binnie/extrabees/ExtraBees.java
@@ -60,6 +60,7 @@ import forestry.core.proxy.Proxies;
 @Mod(
 	modid = ExtraBees.MODID,
 	name = "Binnie's Extra Bees",
+	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 	dependencies = "required-after:" + Constants.CORE_MOD_ID
 )

--- a/extratrees/src/main/java/binnie/extratrees/ExtraTrees.java
+++ b/extratrees/src/main/java/binnie/extratrees/ExtraTrees.java
@@ -33,6 +33,7 @@ import forestry.api.lepidopterology.ButterflyManager;
 @Mod(
 	modid = Constants.EXTRA_TREES_MOD_ID,
 	name = "Binnie's Extra Trees",
+	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 	dependencies = "required-after:" + Constants.CORE_MOD_ID + ";"
 			+      "after:" + Constants.DESIGN_MOD_ID + ";"

--- a/genetics/src/main/java/binnie/genetics/Genetics.java
+++ b/genetics/src/main/java/binnie/genetics/Genetics.java
@@ -41,6 +41,7 @@ import forestry.api.arboriculture.TreeManager;
 @Mod(
 	modid = Constants.GENETICS_MOD_ID,
 	name = "Binnie's Genetics",
+	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
 	dependencies = "required-after:" + Constants.CORE_MOD_ID
 )


### PR DESCRIPTION
Added a tag with a version for submods.
(As already done with BinnieCore)
https://github.com/ForestryMC/Binnie/blob/d503530df2762518559a0c97b5ab44e70dcb0146/core/src/main/java/binnie/core/BinnieCore.java#L59-L67
But I also found that after the build of the jar the tag is not set
After de-compile:
```
@Mod(
    modid = "binniecore",
    name = "Binnie Core",
    version = "unspecified",
    acceptedMinecraftVersions = "[1.12.2,1.13)",
    dependencies = "required-after:forge@[14.23.1.2555,);required-after:forestry@[5.7.0.214,);after:jei@[4.7.8,);"
)
```
It would be nice to fix this, too.