### PR TITLE
Set correct version for mods in jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ apply plugin: 'maven'
 allprojects {
     apply plugin: 'net.minecraftforge.gradle.forge'
 
+    version = version_major + '.' + version_minor + '.' + version_patch
+    if (System.getenv("BUILD_NUMBER") != null) {
+        version = version + "." + System.getenv("BUILD_NUMBER")
+    }
+
     minecraft {
         version = mcversion + "-" + forgeversion
         mappings = mcp_mappings
@@ -31,11 +36,6 @@ allprojects {
     }
 
     group = "binnie" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-
-    version = version_major + '.' + version_minor + '.' + version_patch
-    if (System.getenv("BUILD_NUMBER") != null) {
-        version = version + "." + System.getenv("BUILD_NUMBER")
-    }
 
     sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
     compileJava {


### PR DESCRIPTION
Related to #441 , improve it
Fix this:
After de-compile:
```
@Mod(
    modid = "binniecore",
    name = "Binnie Core",
    version = "unspecified",
    acceptedMinecraftVersions = "[1.12.2,1.13)",
    dependencies = "required-after:forge@[14.23.1.2555,);required-after:forestry@[5.7.0.214,);after:jei@[4.7.8,);"
)
```
to (my test:)
```
@Mod(
	modid = Constants.CORE_MOD_ID,
	name = "Binnie Core",
	version = "2.5.0.117",
	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
	dependencies = "required-after:forge@[14.23.1.2555,);" +
		"required-after:forestry@[5.7.0.214,);" +
		"after:jei@[4.7.8,);"
)
```
and botany (to check the previous request)
```
@Mod(
    modid = "botany",
    name = "Binnie's Botany",
    version = "2.5.0.117",
    acceptedMinecraftVersions = "[1.12.2,1.13)",
    dependencies = "required-after:binniecore;after:genetics;after:binniedesign;"
)
```
to @mezz you were right
https://github.com/ForestryMC/Binnie/pull/441#issuecomment-373601711
this helped