### PR TITLE
Incubator inventory improvement

### DIFF
--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -115,18 +115,18 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 			int potentialSlot = 0;
 			for (final int slot : Incubator.SLOT_QUEUE) {
 				final ItemStack stack = this.getUtil().getStack(slot);
-				if (!stack.isEmpty()) {
-					if (potential == null) {
-						for (final IIncubatorRecipe recipe2 : Incubator.getRecipes()) {
-							final boolean rightLiquid = recipe2.isInputLiquid(liquid);
-							final boolean rightItem = isStackValid(stack, recipe2);
-							if (rightLiquid && rightItem) {
-								potential = recipe2;
-								potentialSlot = slot;
-								break;
-							}
-						}
+				if (stack.isEmpty()) continue;
+				for (final IIncubatorRecipe recipe2 : Incubator.getRecipes()) {
+					final boolean rightLiquid = recipe2.isInputLiquid(liquid);
+					final boolean rightItem = isStackValid(stack, recipe2);
+					if (rightLiquid && rightItem) {
+						potential = recipe2;
+						potentialSlot = slot;
+						break;
 					}
+				}
+				if (potential != null) {
+					break;
 				}
 			}
 			if (potential != null) {

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -88,18 +88,7 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 		}
 		final FluidStack liquid = this.getUtil().getFluid(Incubator.TANK_INPUT);
 		final ItemStack incubator = this.getUtil().getStack(Incubator.SLOT_INCUBATOR);
-		if (this.recipe != null && (incubator.isEmpty() || liquid == null || !this.recipe.isInputLiquid(liquid) || !isStackValid(incubator, recipe))) {
-			this.recipe = null;
-			TransferRequest transferRequest = new TransferRequest(incubator, this.getInventory()).setTargetSlots(Incubator.SLOT_OUTPUT).ignoreValidation();
-			TransferResult transferResult = transferRequest.transfer(null, true);
-			if (transferResult.isSuccess()) {
-				NonNullList<ItemStack> results = transferResult.getRemaining();
-				if (results.size() == 1) {
-					final ItemStack leftover = results.get(0);
-					this.getUtil().setStack(Incubator.SLOT_INCUBATOR, leftover);
-				}
-			}
-		}
+		checkAvailability(liquid, incubator);
 		if (this.recipe == null) {
 			if (liquid == null) {
 				return;
@@ -143,6 +132,21 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 		}
 		if (this.recipe != null) {
 			this.roomForOutput = this.recipe.roomForOutput(this.getUtil());
+		}
+	}
+
+	private void checkAvailability(@Nullable FluidStack liquid, ItemStack incubator) {
+		if (this.recipe != null && (incubator.isEmpty() || liquid == null || !this.recipe.isInputLiquid(liquid) || !isStackValid(incubator, recipe))) {
+			this.recipe = null;
+			TransferRequest transferRequest = new TransferRequest(incubator, this.getInventory()).setTargetSlots(Incubator.SLOT_OUTPUT).ignoreValidation();
+			TransferResult transferResult = transferRequest.transfer(null, true);
+			if (transferResult.isSuccess()) {
+				NonNullList<ItemStack> results = transferResult.getRemaining();
+				if (results.size() == 1) {
+					final ItemStack leftover = results.get(0);
+					this.getUtil().setStack(Incubator.SLOT_INCUBATOR, leftover);
+				}
+			}
 		}
 	}
 }

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -7,7 +7,6 @@ import binnie.core.machines.transfer.TransferResult;
 import net.minecraft.item.ItemStack;
 
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.Util;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -91,10 +91,8 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 		final FluidStack liquid = this.getUtil().getFluid(Incubator.TANK_INPUT);
 		final ItemStack incubator = this.getUtil().getStack(Incubator.SLOT_INCUBATOR);
 		checkAvailability(liquid, incubator);
-		if (this.recipe == null) {
-			if (liquid == null) {
-				return;
-			}
+		addSameFromInputToIncubator(incubator);
+		if (this.recipe == null && liquid != null) {
 			if (!incubator.isEmpty()) {
 				final IIncubatorRecipe recipe = this.getRecipe(incubator, liquid);
 				if (recipe != null) {
@@ -132,18 +130,23 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 		if (this.recipe != null) {
 			this.roomForOutput = this.recipe.roomForOutput(this.getUtil());
 		}
-		addSameFromInputToIncubator(incubator);
 	}
 
 	private void addSameFromInputToIncubator(ItemStack incubator) {
-		if (incubator.isEmpty()) {
+		if (incubator.isEmpty() || incubator.getCount() == incubator.getMaxStackSize()) {
 			return;
 		}
 		for (final int slot : Incubator.SLOT_QUEUE) {
 			final ItemStack stack = this.getUtil().getStack(slot);
 			if (stack.isEmpty()) continue;
-			if (ItemStackUtil.isItemEqual(stack, incubator, false, false)) {
 
+			// Has inner item equal check
+			NonNullList<ItemStack> result = TransferRequest.mergeStacks(stack, incubator);
+
+			getUtil().setStack(slot, result.get(0));
+			getUtil().setStack(Incubator.SLOT_INCUBATOR, result.get(1));
+			if (incubator.getCount() == incubator.getMaxStackSize()) {
+				break;
 			}
 		}
 	}

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -4,7 +4,6 @@ import javax.annotation.Nullable;
 import java.util.Random;
 
 import binnie.core.machines.transfer.TransferResult;
-import binnie.core.util.ItemStackUtil;
 import net.minecraft.item.ItemStack;
 
 import net.minecraft.util.NonNullList;

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java
@@ -4,9 +4,11 @@ import javax.annotation.Nullable;
 import java.util.Random;
 
 import binnie.core.machines.transfer.TransferResult;
+import binnie.core.util.ItemStackUtil;
 import net.minecraft.item.ItemStack;
 
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.Util;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -129,6 +131,20 @@ public class IncubatorLogic extends ComponentProcessIndefinate implements IProce
 		}
 		if (this.recipe != null) {
 			this.roomForOutput = this.recipe.roomForOutput(this.getUtil());
+		}
+		addSameFromInputToIncubator(incubator);
+	}
+
+	private void addSameFromInputToIncubator(ItemStack incubator) {
+		if (incubator.isEmpty()) {
+			return;
+		}
+		for (final int slot : Incubator.SLOT_QUEUE) {
+			final ItemStack stack = this.getUtil().getStack(slot);
+			if (stack.isEmpty()) continue;
+			if (ItemStackUtil.isItemEqual(stack, incubator, false, false)) {
+
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix this.
1. If you add water to the incubator, then the reagent (growth) -incubator will start to work only if you click on the output slot.
No check itemstack emptiness here

https://github.com/ForestryMC/Binnie/blob/51856507b67b3f62e894ae9cd06ae710705f6976/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorLogic.java#L132-L141

Improve

2 The incubator take from the input slots items not one at a time, but only once at a stack (then incubator is empty). I think it's not intuitive. 
And some other refactoring.