### PR TITLE
Update to newest api

### DIFF
--- a/core/src/main/java/binnie/core/machines/transfer/TransferRequest.java
+++ b/core/src/main/java/binnie/core/machines/transfer/TransferRequest.java
@@ -106,9 +106,9 @@ public class TransferRequest {
 				FluidActionResult fluidActionResult;
 				if (this.origin != null && doAdd) {
 					IItemHandler itemHandler = new InvWrapper(this.origin);
-					fluidActionResult = FluidUtil.tryEmptyContainerAndStow(singleCopy, fluidHandler, itemHandler, Fluid.BUCKET_VOLUME, player);
+					fluidActionResult = FluidUtil.tryEmptyContainerAndStow(singleCopy, fluidHandler, itemHandler, Fluid.BUCKET_VOLUME, player, doAdd);
 					if (!fluidActionResult.isSuccess()) {
-						fluidActionResult = FluidUtil.tryFillContainerAndStow(singleCopy, fluidHandler, itemHandler, Fluid.BUCKET_VOLUME, player);
+						fluidActionResult = FluidUtil.tryFillContainerAndStow(singleCopy, fluidHandler, itemHandler, Fluid.BUCKET_VOLUME, player, doAdd);
 					}
 				} else {
 					fluidActionResult = FluidUtil.tryEmptyContainer(singleCopy, fluidHandler, Fluid.BUCKET_VOLUME, player, doAdd);


### PR DESCRIPTION
In general, everything is fine, but regressions are possible.
Because The current code uses the option permanently with the parameter true
```
@Deprecated // TODO: remove in 1.13
    @Nonnull
    public static FluidActionResult tryEmptyContainerAndStow(@Nonnull ItemStack container, IFluidHandler fluidDestination, IItemHandler inventory, int maxAmount, @Nullable EntityPlayer player)
    {
        return tryEmptyContainerAndStow(container, fluidDestination, inventory, maxAmount, player, true);
    }
```