### PR TITLE
Extratrees machines

### DIFF
--- a/core/src/main/java/binnie/core/machines/inventory/BaseSlot.java
+++ b/core/src/main/java/binnie/core/machines/inventory/BaseSlot.java
@@ -60,6 +60,7 @@ public abstract class BaseSlot<V> implements INbtWritable, INbtReadable, IValida
 	}
 
 	public void forbidInteraction() {
+		this.readOnly = true;
 		this.forbidInsertion();
 		this.forbidExtraction();
 	}


### PR DESCRIPTION
Improve forbidInteraction
Bug with fruit press.
https://github.com/ForestryMC/Binnie/blob/274a02b726f031c824a1d46d611e3f66086b8830/extratrees/src/main/java/binnie/extratrees/machines/fruitpress/FruitPressMachine.java#L35-L37
Process slot is marked by forbidInt but during the work (when a fruit is placed in the slot), shift-click items from the inventory will add items not in the input slot but into the processing slot.
In addition, you can click in the processing slot and the subject disappears.
The commit fixes this