### PR TITLE
Add stub for flower block

### DIFF
--- a/botany/src/main/java/binnie/botany/blocks/BlockFlower.java
+++ b/botany/src/main/java/binnie/botany/blocks/BlockFlower.java
@@ -177,6 +177,11 @@ public class BlockFlower extends BlockContainer implements IColoredBlock, IState
 	}
 
 	@Override
+	public String getUnlocalizedName() {
+		return String.format("%s.block.flower", Botany.instance.getModId());
+	}
+
+	@Override
 	@SideOnly(Side.CLIENT)
 	public int colorMultiplier(IBlockState state, @Nullable IBlockAccess world, @Nullable BlockPos pos, int tintIndex) {
 		if (world != null && pos != null) {

--- a/botany/src/main/resources/assets/botany/lang/en_US.lang
+++ b/botany/src/main/resources/assets/botany/lang/en_US.lang
@@ -37,6 +37,7 @@ botany.plant.decaying_flower=Decaying Flower
 botany.ceramic.name=%s Ceramic Block
 botany.ceramic.block.name=%s Ceramic Block
 botany.pigmented.glass.name=%s Pigmented Glass
+botany.block.flower.name=Botany Flower
 
 botany.ceramic.type.tile.name=%s Ceramic Tile
 botany.ceramic.type.brick.name=%s Ceramic Bricks

--- a/botany/src/main/resources/assets/botany/lang/ru_RU.lang
+++ b/botany/src/main/resources/assets/botany/lang/ru_RU.lang
@@ -37,6 +37,7 @@ botany.plant.decaying_flower=Разлагающийся цветок
 botany.ceramic.name=Керамический блок (%s)
 botany.ceramic.block.name=Керамический блок (%s)
 botany.pigmented.glass.name=Пигментированное стекло (%s)
+botany.block.flower.name=Цветок Botany
 
 botany.ceramic.type.tile.name=%s керамическая плитка
 botany.ceramic.type.brick.name=%s керамические кирпичи


### PR DESCRIPTION
I wanted to make an tooltip, but in the current version of block registration it would not seem easy.
Before:
![2018-03-24_22 03 20](https://user-images.githubusercontent.com/29846693/37863963-10ecb666-2fb3-11e8-8172-051cc8fde27f.png)
![2018-03-24_22 03 21](https://user-images.githubusercontent.com/29846693/37863964-111a9fe0-2fb3-11e8-88bb-e157a29e6b5d.png)
After:
![2018-03-24_22 28 14](https://user-images.githubusercontent.com/29846693/37863967-1b954bd2-2fb3-11e8-9d23-7426c857599c.png)
![2018-03-24_22 28 16](https://user-images.githubusercontent.com/29846693/37863968-1bc38ba0-2fb3-11e8-9ac1-7dbbd0e9ee91.png)
