### PR TITLE
Proposal: Logging not localized keys

### DIFF
--- a/core/src/main/java/binnie/core/proxy/I18NClient.java
+++ b/core/src/main/java/binnie/core/proxy/I18NClient.java
@@ -3,6 +3,7 @@ package binnie.core.proxy;
 import binnie.core.ModId;
 import binnie.core.util.Log;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.launchwrapper.Launch;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -11,6 +12,8 @@ import java.util.IllegalFormatException;
 
 @SideOnly(Side.CLIENT)
 public class I18NClient implements I18NProxy {
+
+    private final boolean devEnvironment = Launch.blackboard.get("fml.deobfuscatedEnvironment") == Boolean.TRUE;
 
     public String localiseOrBlank(String key) {
         String trans = localise(key);
@@ -21,7 +24,9 @@ public class I18NClient implements I18NProxy {
         if (I18n.hasKey(key)) {
             return I18n.format(key);
         } else {
-            Log.warning("Key not localized: " + key);
+            if (devEnvironment) {
+                Log.warning("Key not localized: " + key);
+            }
             return key;
         }
     }

--- a/core/src/main/java/binnie/core/proxy/I18NClient.java
+++ b/core/src/main/java/binnie/core/proxy/I18NClient.java
@@ -21,6 +21,7 @@ public class I18NClient implements I18NProxy {
         if (I18n.hasKey(key)) {
             return I18n.format(key);
         } else {
+            Log.warning("Key not localized: " + key);
             return key;
         }
     }


### PR DESCRIPTION
Now the output is a bit strange.
```
[10:36:25] [main/WARN]: Key not localized: Apple Juice
[10:36:25] [main/WARN]: Key not localized: Apricot Juice
[10:36:25] [main/WARN]: Key not localized: Banana Juice
[10:36:25] [main/WARN]: Key not localized: Cherry Juice
[10:36:25] [main/WARN]: Key not localized: Elderberry Juice
[10:36:25] [main/WARN]: Key not localized: Lemon Juice
[10:36:25] [main/WARN]: Key not localized: Lime Juice
[10:36:25] [main/WARN]: Key not localized: Orange Juice
[10:36:25] [main/WARN]: Key not localized: Peach Juice
[10:36:25] [main/WARN]: Key not localized: Plum Juice
```

But allows you to find errors
```
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.dry.manual.fert
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.dry.acid.manual.fert
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.dry.neutral.manual.fert
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.dry.alkaline.manual.fert
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.normal.manual.fert
[10:36:42] [main/WARN]: Key not localized: binnie.circuit.garden.normal.acid.manual.fert
```