### PR TITLE
Use forestry world generator for extra trees

### DIFF
--- a/extratrees/src/main/java/binnie/extratrees/gen/TreeGenBase.java
+++ b/extratrees/src/main/java/binnie/extratrees/gen/TreeGenBase.java
@@ -4,12 +4,11 @@ import java.util.Random;
 
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.WorldGenerator;
 
 import forestry.api.arboriculture.ITree;
 import forestry.api.world.ITreeGenData;
 
-public class TreeGenBase extends WorldGenerator {
+public class TreeGenBase {
 	protected ITree tree;
 	protected ITreeGenData treeGen;
 	protected World world;
@@ -39,10 +38,9 @@ public class TreeGenBase extends WorldGenerator {
 		return a + this.rand.nextFloat() * (b - a);
 	}
 
-	@Override
 	public boolean generate(World worldIn, Random rand, BlockPos position) {
 		this.world = worldIn;
-		this.startX = position.getX();
+		this.startX = position.getX();	
 		this.startY = position.getY();
 		this.startZ = position.getZ();
 		this.girth = this.tree.getGirth();

--- a/extratrees/src/main/java/binnie/extratrees/genetics/ETTreeDefinition.java
+++ b/extratrees/src/main/java/binnie/extratrees/genetics/ETTreeDefinition.java
@@ -2084,7 +2084,7 @@ public enum ETTreeDefinition implements IStringSerializable, ITreeDefinition, IT
 		}
 		IAlleleTreeSpeciesBuilder speciesBuilder = TreeManager.treeFactory.createSpecies(getUID(), String.format(unlocalizedName, getUID()), getAuthority(), String.format(unlocalizedDesc, getUID()), isDominant(),
 			branch, getBinomial(), Constants.EXTRA_TREES_MOD_ID, leafSpriteProvider, saplingType.getGermlingModelProvider(leafColor, woodColor), woodProvider, this, new ETLeafProvider()
-		);
+		).setRarity(0.005F);
 		setSpeciesProperties(speciesBuilder);
 		species = speciesBuilder.build();
 		branch.addMemberSpecies(species);


### PR DESCRIPTION
Simlarly to https://github.com/ForestryMC/Binnie/pull/486 if Extra Trees uses the forestry world generator then it's much easier to do things like dimension configs and https://github.com/ForestryMC/ForestryMC/issues/2039.

Numbers may need tweaking for tree frequency but it didn't look too bad for me. This also allows for control over tree rarity in extra trees.

One slightly odd effect is that the trees in world will have a tooltip saying they came from Forestry Aboriculture since that's what placed them there.