### PR TITLE
Small Refactor Incubator

### DIFF
--- a/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipeLarvae.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/IncubatorRecipeLarvae.java
@@ -17,7 +17,7 @@ public class IncubatorRecipeLarvae extends IncubatorRecipe {
 
 	@Override
 	public ItemStack getOutputStack(final MachineUtil machine) {
-		final ItemStack larvae = machine.getStack(3);
+		final ItemStack larvae = machine.getStack(Incubator.SLOT_INCUBATOR);
 		final IBee bee = BeeManager.beeRoot.getMember(larvae);
 		if (bee == null) {
 			return ItemStack.EMPTY;

--- a/genetics/src/main/java/binnie/genetics/machine/incubator/PackageIncubator.java
+++ b/genetics/src/main/java/binnie/genetics/machine/incubator/PackageIncubator.java
@@ -27,9 +27,7 @@ public class PackageIncubator extends GeneticMachine.PackageGeneticBase implemen
 		}
 		InventorySlot slotIncubator = inventory.addSlot(Incubator.SLOT_INCUBATOR, getSlotRL("incubator"));
 		slotIncubator.forbidInteraction();
-		slotIncubator.setReadOnly();
 		for (InventorySlot slot : inventory.addSlotArray(Incubator.SLOT_OUTPUT, getSlotRL("output"))) {
-			slot.forbidInsertion();
 			slot.setReadOnly();
 		}
 		new ComponentPowerReceptor(machine, 2000);


### PR DESCRIPTION
1. `slotIncubator.setReadOnly();` can be safely removed, because `slotIncubator.forbidInteraction()` do the same.
https://github.com/ForestryMC/Binnie/blob/548b63a1a90eb923d5b320e199c3523f4ebd912f/core/src/main/java/binnie/core/machines/inventory/BaseSlot.java#L29-L32
https://github.com/ForestryMC/Binnie/blob/548b63a1a90eb923d5b320e199c3523f4ebd912f/core/src/main/java/binnie/core/machines/inventory/BaseSlot.java#L62-L66
2. Same below with `slot.forbidInsertion();`