### PR TITLE
I18n-localise_improve.

### DIFF
--- a/core/src/main/java/binnie/core/proxy/I18NClient.java
+++ b/core/src/main/java/binnie/core/proxy/I18NClient.java
@@ -44,12 +44,13 @@ public class I18NClient implements I18NProxy {
     }
 
     public String localise(String key, Object... format) {
-        try {
+        if (I18n.hasKey(key)) {
             return I18n.format(key, format);
-        } catch (IllegalFormatException e) {
-            String errorMessage = "Format error: " + key;
-            Log.error(errorMessage, e);
-            return errorMessage;
+        } else {
+            if (devEnvironment) {
+                Log.warning("Key not localized: " + key);
+            }
+            return key;
         }
     }
 

--- a/core/src/main/java/binnie/core/proxy/I18NClient.java
+++ b/core/src/main/java/binnie/core/proxy/I18NClient.java
@@ -48,7 +48,7 @@ public class I18NClient implements I18NProxy {
             return I18n.format(key, format);
         } else {
             if (devEnvironment) {
-                Log.warning("Key not localized: " + key);
+                Log.warning("Key(format) not localized: " + key);
             }
             return key;
         }

--- a/core/src/main/java/binnie/core/proxy/I18NClient.java
+++ b/core/src/main/java/binnie/core/proxy/I18NClient.java
@@ -23,12 +23,11 @@ public class I18NClient implements I18NProxy {
     public String localise(String key) {
         if (I18n.hasKey(key)) {
             return I18n.format(key);
-        } else {
-            if (devEnvironment) {
-                Log.warning("Key not localized: " + key);
-            }
-            return key;
         }
+        if (devEnvironment) {
+            Log.warning("Key not localized: " + key);
+        }
+        return key;
     }
 
     public String localise(ModId modId, String path, Object... format) {
@@ -46,12 +45,11 @@ public class I18NClient implements I18NProxy {
     public String localise(String key, Object... format) {
         if (I18n.hasKey(key)) {
             return I18n.format(key, format);
-        } else {
-            if (devEnvironment) {
-                Log.warning("Key(format) not localized: " + key);
-            }
-            return key;
         }
+        if (devEnvironment) {
+            Log.warning("Key(format) not localized: " + key);
+        }
+        return key;
     }
 
     public String localise(ResourceLocation key, Object... format) {

--- a/extratrees/src/main/resources/assets/extratrees/lang/en_US.lang
+++ b/extratrees/src/main/resources/assets/extratrees/lang/en_US.lang
@@ -774,6 +774,7 @@ extratrees.gui.database.tab.butterfly.branches.overview=Overview
 extratrees.gui.database.tab.butterfly.branches.species=Species
 extratrees.gui.database.tab.butterfly.breeder=Breeder
 
+extratrees.allele.metabolism.normal=Normal
 extratrees.allele.metabolism.highest=Highest
 extratrees.allele.metabolism.higher=Higher
 extratrees.allele.metabolism.high=High

--- a/extratrees/src/main/resources/assets/extratrees/lang/ru_RU.lang
+++ b/extratrees/src/main/resources/assets/extratrees/lang/ru_RU.lang
@@ -774,6 +774,7 @@ extratrees.gui.database.tab.butterfly.branches.overview=Обзор
 extratrees.gui.database.tab.butterfly.branches.species=Вид
 extratrees.gui.database.tab.butterfly.breeder=Производитель
 
+extratrees.allele.metabolism.normal=Нормальный
 extratrees.allele.metabolism.highest=Самый быстрый
 extratrees.allele.metabolism.higher=Очень быстрый
 extratrees.allele.metabolism.high=Быстрый


### PR DESCRIPTION
`I18n.format(key, format);` does not throw IllegalFormatException on format error. It just add same message like in code
```
Locale.java
public String formatMessage(String translateKey, Object[] parameters)
    {
        String s = this.translateKeyPrivate(translateKey);

        try
        {
            return String.format(s, parameters);
        }
        catch (IllegalFormatException var5)
        {
            return "Format error: " + s;
        }
    }
```
So current code is useless for finding translation errors. I refactor it to be same with
https://github.com/ForestryMC/Binnie/blob/12be4c8eb5cf28ca30d019a3db024c46e59f771a/core/src/main/java/binnie/core/proxy/I18NClient.java#L23-L32