### PR TITLE
Revert back translation mechanic in WoodManager

### DIFF
--- a/extratrees/src/main/java/binnie/extratrees/wood/WoodManager.java
+++ b/extratrees/src/main/java/binnie/extratrees/wood/WoodManager.java
@@ -17,9 +17,9 @@ import forestry.api.arboriculture.IWoodType;
 import forestry.api.arboriculture.TreeManager;
 import forestry.api.arboriculture.WoodBlockKind;
 import forestry.arboriculture.IWoodTyped;
+import forestry.core.utils.Translator;
 
 import binnie.core.block.TileEntityMetadata;
-import binnie.core.util.I18N;
 import binnie.extratrees.api.CarpentryManager;
 import binnie.design.api.IDesignMaterial;
 import binnie.extratrees.blocks.decor.FenceDescription;
@@ -41,11 +41,11 @@ public class WoodManager {
 
 		if (woodType instanceof EnumETLog || woodType instanceof EnumShrubLog) {
 			String customUnlocalizedName = "tile.et." + blockKind + "." + woodType + ".name";
-			if (I18N.canLocalise(customUnlocalizedName)) {
-				displayName = I18N.localise(customUnlocalizedName);
+			if (Translator.canTranslateToLocal(customUnlocalizedName)) {
+				displayName = Translator.translateToLocal(customUnlocalizedName);
 			} else {
-				String woodGrammar = I18N.localise("for." + blockKind + ".grammar");
-				String woodTypeName = I18N.localise("et.trees.woodType." + woodType);
+				String woodGrammar = Translator.translateToLocal("for." + blockKind + ".grammar");
+				String woodTypeName = Translator.translateToLocal("et.trees.woodType." + woodType);
 
 				displayName = woodGrammar.replaceAll("%TYPE", woodTypeName);
 			}
@@ -54,7 +54,7 @@ public class WoodManager {
 		}
 
 		if (wood.isFireproof()) {
-			displayName = I18N.localise("tile.for.fireproof", displayName);
+			displayName = Translator.translateToLocalFormatted("tile.for.fireproof", displayName);
 		}
 
 		return displayName;
@@ -110,7 +110,7 @@ public class WoodManager {
 		}
 		return TreeManager.woodAccess.getStack(plank.getWoodType(), WoodBlockKind.FENCE_GATE, false);
 	}
-	
+
 	public static ItemStack getDoor(final IPlankType plank) {
 		if (plank == VanillaPlanks.OAK) {
 			return new ItemStack(Items.OAK_DOOR);


### PR DESCRIPTION
It is too dependent on forestry (replacement of the text)
Client I18N cannot be used for now.