### PR TITLE
Fix osage/osange orange

### DIFF
--- a/extratrees/src/main/resources/assets/extratrees/lang/en_US.lang
+++ b/extratrees/src/main/resources/assets/extratrees/lang/en_US.lang
@@ -308,6 +308,7 @@ extratrees.species.wildcherry.name=Wild Cherry
 extratrees.species.sourcherry.name=Sour Cherry
 extratrees.species.blackcherry.name=Black Cherry
 extratrees.species.orange.name=Orange
+extratrees.species.osange_orange.name=Osagne-Orange
 extratrees.species.manderin.name=Manderine
 extratrees.species.satsuma.name=Satsuma
 extratrees.species.tangerine.name=Tangerine


### PR DESCRIPTION
Closes https://github.com/ForestryMC/Binnie/issues/399. There was no localisation key in en_US so the game defaulted to en_GB which has a different spelling.