### PR TITLE
Cache result of ComponentInventorySlots.getSlotsForFace

### DIFF
--- a/core/src/main/java/binnie/core/machines/inventory/ComponentInventorySlots.java
+++ b/core/src/main/java/binnie/core/machines/inventory/ComponentInventorySlots.java
@@ -27,10 +27,12 @@ public class ComponentInventorySlots extends ComponentInventory implements IInve
 	private static final float ACCEL = 0.05f;
 
 	private final Map<Integer, InventorySlot> inventory;
+	private final Map<EnumFacing, int[]> slotsForFace;
 
 	public ComponentInventorySlots(final IMachine machine) {
 		super(machine);
 		this.inventory = new LinkedHashMap<>();
+		this.slotsForFace = new LinkedHashMap<>();
 	}
 
 	@Override
@@ -200,10 +202,14 @@ public class ComponentInventorySlots extends ComponentInventory implements IInve
 
 	@Override
 	public int[] getSlotsForFace(final EnumFacing facing) {
-		return inventory.values().stream().
-			filter(slot -> slot.canInsert() || slot.canExtract())
-			.mapToInt(InventorySlot::getIndex)
-			.toArray();
+		if (!slotsForFace.containsKey(facing)) {
+			slotsForFace.put(facing, inventory.values().stream()
+				.filter(slot -> slot.canInsert() || slot.canExtract())
+				.mapToInt(InventorySlot::getIndex)
+				.toArray()
+			);
+		}
+		return slotsForFace.get(facing);
 	}
 
 	@Override


### PR DESCRIPTION
ThermalDynamics calls this function often enough that it can cause
performance problems on busy servers.  Since the value of
getSlotsForFace does not change after the machine init has occured this
change should be harmless.

NPS dump, look under:
onPostWorldTick -> ServoItem.tick -> SidedInvWrapper.getSlots() -> ComponentInventorySlots.func_180463_a

[sample.zip](https://github.com/ForestryMC/Binnie/files/1977584/sample.zip)
