### PR TITLE
update forestry api

### DIFF
--- a/botany/src/main/java/binnie/botany/GardeningManager.java
+++ b/botany/src/main/java/binnie/botany/GardeningManager.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import forestry.api.climate.ClimateManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -101,7 +102,7 @@ public class GardeningManager implements IGardeningManager {
 
 	@Override
 	public float getBiomeMoisture(World world, BlockPos pos) {
-		IClimateState info = ForestryAPI.climateManager.getClimateState(world, pos);
+		IClimateState info = ClimateManager.climateRoot.getState(world, pos);
 		double humidity = info.getHumidity();
 		double temperature = info.getTemperature();
 		double moisture = 3.2 * (humidity - 0.5) - 0.4 * (1.0 + temperature + 0.5 * temperature * temperature) + 1.1 - 1.6 * (temperature - 0.9) * (temperature - 0.9) - 0.002 * (pos.getY() - 64);
@@ -110,7 +111,7 @@ public class GardeningManager implements IGardeningManager {
 
 	@Override
 	public float getBiomePH(World world, BlockPos pos) {
-		IClimateState info = ForestryAPI.climateManager.getClimateState(world, pos);
+		IClimateState info = ClimateManager.climateRoot.getState(world, pos);
 		double humidity = info.getHumidity();
 		double temperature = info.getTemperature();
 		return (float) (-3.0 * (humidity - 0.5) + 0.5 * (temperature - 0.699999988079071) * (temperature - 0.699999988079071) + 0.02f * (pos.getY() - 64) - 0.15000000596046448);

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ forgeversion=14.23.2.2627
 mcp_mappings=snapshot_20170918
 curse_project_id=223525
 
-forestry_version=5.8.0.255
+forestry_version=5.8.2.362
 forestry_mcversion=1.12.2
 ic2_version=2.8.27-ex112
 


### PR DESCRIPTION
In the newer versions of forestry, `IClimateManager.getClimateState` no longer exists. It has been moved to `ClimateManager.climateRoot.getState`, which I have changed it to in this pr.

Crash report this pr fixes: http://hatebin.com/nbusryauqt