### PR TITLE
move compartment recipe registration to init

### DIFF
--- a/core/src/main/java/binnie/core/machines/storage/ModuleStorage.java
+++ b/core/src/main/java/binnie/core/machines/storage/ModuleStorage.java
@@ -22,10 +22,6 @@ public class ModuleStorage implements IInitializable {
 
 	@Override
 	public void init() {
-	}
-
-	@Override
-	public void postInit() {
 		RecipeUtil recipeUtil = new RecipeUtil(Constants.CORE_MOD_ID);
 		final String ironGear = OreDictionary.getOres("gearIron").isEmpty() ? "ingotIron" : "gearIron";
 		final String goldGear = OreDictionary.getOres("gearGold").isEmpty() ? "ingotGold" : "gearGold";


### PR DESCRIPTION
Needs testing from me, the recipes definitely still work but I haven't checked with crafttweaker yet due to it not playing well with the way the project is set up in dev.

This seems to be where forestry registers its recipes though and is an easy fix.