### PR TITLE
move config reading to early preinit to fix broken hopefield config

### DIFF
--- a/core/src/main/java/binnie/core/modules/ModuleContainer.java
+++ b/core/src/main/java/binnie/core/modules/ModuleContainer.java
@@ -54,6 +54,9 @@ public class ModuleContainer implements forestry.api.modules.IModuleContainer {
 	}
 
 	protected void runPreInit(FMLPreInitializationEvent event) {
+		for (IConfigHandler handler : configHandlers) {
+			handler.loadConfig();
+		}
 		for (IForestryModule module : loadedModules) {
 			module.registerItemsAndBlocks();
 		}
@@ -66,9 +69,6 @@ public class ModuleContainer implements forestry.api.modules.IModuleContainer {
 		for (IForestryModule module : loadedModules) {
 			module.doInit();
 			module.registerRecipes();
-		}
-		for (IConfigHandler handler : configHandlers) {
-			handler.loadConfig();
 		}
 	}
 

--- a/extratrees/src/main/java/binnie/extratrees/config/ConfigurationMain.java
+++ b/extratrees/src/main/java/binnie/extratrees/config/ConfigurationMain.java
@@ -21,7 +21,7 @@ public class ConfigurationMain implements IConfigHandler {
 	public void loadConfig() {
 		//TODO: Localise comment
 		//Core Module
-		hopeField = config.getBoolean("village.hopeField", "general", alterLemon, "Adds a hope field to the village generation.");
+		hopeField = config.getBoolean("village.hopeField", "general", hopeField, "Adds a hope field to the village generation.");
 		//Wood Module
 		alterLemon = config.getBoolean("lemon.citrus.family", "general", alterLemon, "Uses reflection to convert the Forestry lemon tree to the Citrus family.");
 		if (config.hasChanged()) {

--- a/extratrees/src/main/java/binnie/extratrees/village/VillageHopeField.java
+++ b/extratrees/src/main/java/binnie/extratrees/village/VillageHopeField.java
@@ -26,10 +26,6 @@ public class VillageHopeField extends StructureVillagePieces.Village {
 	private Block cropTypeC;
 	private Block cropTypeD;
 
-	@SuppressWarnings("unused")
-	public VillageHopeField() {
-	}
-
 	public VillageHopeField(StructureVillagePieces.Start start, int type, Random rand, StructureBoundingBox boundingBox, EnumFacing facing) {
 		super(start, type);
 		this.setCoordBaseMode(facing);

--- a/extratrees/src/main/java/binnie/extratrees/village/VillageHopeField.java
+++ b/extratrees/src/main/java/binnie/extratrees/village/VillageHopeField.java
@@ -26,6 +26,12 @@ public class VillageHopeField extends StructureVillagePieces.Village {
 	private Block cropTypeC;
 	private Block cropTypeD;
 
+	//this is necessary for constructing when loading the world
+	@SuppressWarnings("unused")
+	public VillageHopeField() {
+	}
+
+
 	public VillageHopeField(StructureVillagePieces.Start start, int type, Random rand, StructureBoundingBox boundingBox, EnumFacing facing) {
 		super(start, type);
 		this.setCoordBaseMode(facing);


### PR DESCRIPTION
I am unaware of any reason that the config needs to be read later.
Also fixes bug where the default value for the hopefield config was the alterlemon option (I don't thnk this actually makes any difference though).
After this 'ConfigurationMain.hopefield' actually appeared as false in my breakpoints and the relevant village registration was skipped.

BTW is hopefield meant to be a pun or is it just a spelling error?