### PR TITLE
Nbtfix

### DIFF
--- a/src/main/java/binnie/core/block/TileEntityMetadata.java
+++ b/src/main/java/binnie/core/block/TileEntityMetadata.java
@@ -74,12 +74,8 @@ public class TileEntityMetadata extends TileEntity {
 	}
 
 	public static ItemStack getItemStack(Block block, int damage) {
-		NBTTagCompound tag = new NBTTagCompound();
-		tag.setInteger("meta", damage);
-
 		ItemStack item = new ItemStack(block, 1, 0);
-		item.setItemDamage((damage < 16387) ? damage : 16387);
-		item.setTagCompound(tag);
+		item.setItemDamage(Math.min(damage, 16387));
 		return item;
 	}
 


### PR DESCRIPTION
Fix issue where harvested door items would not stack with freshly crafted doors.
    
This patch removes the unused NBT stored block meta from harvested blocks tiles.
