### PR TITLE
fix(fruitdrop): align fruit drop to forestry

### DIFF
--- a/src/main/java/binnie/extratrees/genetics/ExtraTreeFruitGene.java
+++ b/src/main/java/binnie/extratrees/genetics/ExtraTreeFruitGene.java
@@ -375,7 +375,7 @@ public enum ExtraTreeFruitGene implements IAlleleFruit, IFruitProvider {
 
 		float modeYieldMod = 1.0f;
 		for (Map.Entry<ItemStack, Float> entry2 : products.entrySet()) {
-			if (world.rand.nextFloat() <= genome.getYield() * modeYieldMod * entry2.getValue() * 5.0f * stage) {
+			if (world.rand.nextFloat() <= genome.getYield() * modeYieldMod * entry2.getValue() * stage) {
 				product2.add(entry2.getKey().copy());
 			}
 		}


### PR DESCRIPTION
ExtraTrees had a fuit drop rate of five times that of Forestry.
This patch removes the hard-coded 5× multiplier over yield so that
fruit drop rate is same as forestry trees with same yeild trait.