### PR TITLE
Fix issue #645: Make alcohols have visible effects again

### DIFF
--- a/core/src/main/java/binnie/core/liquid/AlcoholEffect.java
+++ b/core/src/main/java/binnie/core/liquid/AlcoholEffect.java
@@ -5,10 +5,11 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.potion.PotionEffect;
 
 public class AlcoholEffect {
-	public static void makeDrunk(final EntityPlayer player, final float strength) {
+	public static void makeDrunk(final EntityPlayer player, final float abv) {
 		PotionEffect potionEffect = player.getActivePotionEffect(MobEffects.NAUSEA);
 		final int existingStrength = potionEffect != null ? potionEffect.getAmplifier() : 0;
 		final int existingTime = potionEffect != null ? potionEffect.getDuration() : 0;
+		final float strength = 100 * abv;
 		int time = (int) (100.0 * Math.sqrt(strength)) + existingTime;
 		final float intensity = 0.1f * strength + existingStrength + existingTime / 500;
 		if (time < 5) {
@@ -25,7 +26,7 @@ public class AlcoholEffect {
 		}
 		player.addPotionEffect(new PotionEffect(MobEffects.NAUSEA, time, (int) intensity, false, true));
 		if (slowIntense > 0.0f) {
-			player.addPotionEffect(new PotionEffect(MobEffects.NAUSEA, time, (int) slowIntense, false, true));
+			player.addPotionEffect(new PotionEffect(MobEffects.SLOWNESS, time, (int) slowIntense, false, true));
 		}
 		if (blindIntense > 0.0f) {
 			player.addPotionEffect(new PotionEffect(MobEffects.BLINDNESS, time, (int) blindIntense, false, true));


### PR DESCRIPTION
Fixes https://github.com/ForestryMC/Binnie/issues/645 by rescaling alcohol ABVs in the time calculations in AlcoholEffect.makedrunk(). See issue for description of cause and this fix.

Also fixes secondary effect of drunkenness to be slowness instead of a repeat of nausea.