### PR TITLE
made it possible to have separate jars - still some issues though

### DIFF
--- a/all/src/main/resources/mcmod.info
+++ b/all/src/main/resources/mcmod.info
@@ -1,0 +1,73 @@
+[
+  {
+    "modid": "binniecore",
+    "name": "Binnie Core",
+    "description": "Base mod for Binnie's Mods, with lots of common code.",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "https://minecraft.curseforge.com/projects/binnies-mods",
+    "updateUrl": "",
+    "authorList": [ "Binnie" ],
+    "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
+    "logoFile": "/assets/binniecore/logo.png",
+    "parent": "",
+    "requiredMods": [ "forestry" ],
+    "dependencies": [ "forestry" ]
+  },
+  {
+    "modid": "extrabees",
+    "name": "Binnie's Extra Bees",
+    "description": "Adds new bees and products to expand the bee breeding in Forestry.",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "https://minecraft.curseforge.com/projects/binnies-mods",
+    "updateUrl": "",
+    "authorList": [ "Binnie" ],
+    "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
+    "logoFile": "/assets/extrabees/logo.png",
+    "parent": "",
+    "dependencies": [ "BinnieCore" ]
+  },
+  {
+    "modid": "extratrees",
+    "name": "Binnie's Extra Trees",
+    "description": "Adds new trees, aesthetic blocks and alcohol production.",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "https://minecraft.curseforge.com/projects/binnies-mods",
+    "updateUrl": "",
+    "authorList": [ "Binnie" ],
+    "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
+    "logoFile": "/assets/extratrees/logo.png",
+    "parent": "",
+    "dependencies": [ "BinnieCore" ]
+  },
+  {
+    "modid": "botany",
+    "name": "Binnie's Botany",
+    "description": "Adds breedable flowers.",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "https://minecraft.curseforge.com/projects/binnies-mods",
+    "updateUrl": "",
+    "authorList": [ "Binnie" ],
+    "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
+    "logoFile": "/assets/botany/logo.png",
+    "parent": "",
+    "dependencies": [ "BinnieCore" ]
+  },
+  {
+    "modid": "genetics",
+    "name": "Binnie's Genetics",
+    "description": "Adds genetic manipulation for bees, trees, butterflies and flowers.",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "https://minecraft.curseforge.com/projects/binnies-mods",
+    "updateUrl": "",
+    "authorList": [ "Binnie" ],
+    "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
+    "logoFile": "/assets/genetics/logo.png",
+    "parent": "",
+    "dependencies": [ "BinnieCore" ]
+  }
+]

--- a/botany/src/main/resources/mcmod.info
+++ b/botany/src/main/resources/mcmod.info
@@ -1,17 +1,16 @@
 [
   {
-    "modid": "binniecore",
-    "name": "Binnie Core",
-    "description": "Base mod for Binnie's Mods, with lots of common code.",
+    "modid": "botany",
+    "name": "Binnie's Botany",
+    "description": "Adds breedable flowers.",
     "version": "${version}",
     "mcversion": "${mcversion}",
     "url": "https://minecraft.curseforge.com/projects/binnies-mods",
     "updateUrl": "",
     "authorList": [ "Binnie" ],
     "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
-    "logoFile": "/assets/binniecore/logo.png",
+    "logoFile": "/assets/botany/logo.png",
     "parent": "",
-    "requiredMods": [ "forestry" ],
-    "dependencies": [ "forestry" ]
+    "dependencies": [ "BinnieCore" ]
   }
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jar {
 }
 
 task coreJar(type: Jar){
-    classifier = 'core'
+    baseName = 'binnies-core'
     mainProjects.subList(0, 2).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
@@ -130,7 +130,7 @@ task coreJar(type: Jar){
 }
 
 task botanyJar(type: Jar){
-    classifier = 'botany'
+    baseName = 'binnies-botany'
     mainProjects.subList(2, 4).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
@@ -140,7 +140,7 @@ task botanyJar(type: Jar){
 }
 
 task designJar(type: Jar){
-    classifier = 'design'
+    baseName = 'binnies-design'
     mainProjects.subList(4, 6).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
@@ -150,7 +150,7 @@ task designJar(type: Jar){
 }
 
 task extraBeesJar(type: Jar){
-    classifier = 'extrabees'
+    baseName = 'binnies-extrabees'
     mainProjects.subList(6, 7).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
@@ -160,7 +160,7 @@ task extraBeesJar(type: Jar){
 }
 
 task extraTreesJar(type: Jar){
-    classifier = 'extratrees'
+    baseName = 'binnies-extratrees'
     mainProjects.subList(7, 9).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
@@ -170,7 +170,7 @@ task extraTreesJar(type: Jar){
 }
 
 task geneticsJar(type: Jar){
-    classifier = 'genetics'
+    baseName = 'binnies-genetics'
     mainProjects.subList(9, 11).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs

--- a/build.gradle
+++ b/build.gradle
@@ -103,12 +103,75 @@ allprojects {
     }
 }
 
-def mainProjects = [':core', ':core-api', ':botany', ':botany-api', ':design', ':design-api', ':extrabees', ':extratrees', 'extratrees-api', ':genetics', 'genetics-api']
+def mainProjects = [':core', ':core-api', ':botany', ':botany-api', ':design', ':design-api', ':extrabees', ':extratrees', 'extratrees-api', ':genetics', 'genetics-api', 'all']
         .collect{ subproject -> project(subproject) }
 mainProjects.each { subproject -> evaluationDependsOn( subproject.path ) }
 jar.dependsOn mainProjects.tasks['classes']
 jar {
-    mainProjects.each { subproject ->
+    mainProjects.subList(0, 11).each { subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from (subproject.sourceSets.main.output.resourcesDir) {
+            exclude 'mcmod.info'
+        }
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+    from mainProjects.get(11).sourceSets.main.output.resourcesDir
+}
+
+task coreJar(type: Jar){
+    classifier = 'core'
+    mainProjects.subList(0, 2).each {subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from subproject.sourceSets.main.output.resourcesDir
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+}
+
+task botanyJar(type: Jar){
+    classifier = 'botany'
+    mainProjects.subList(2, 4).each {subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from subproject.sourceSets.main.output.resourcesDir
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+}
+
+task designJar(type: Jar){
+    classifier = 'design'
+    mainProjects.subList(4, 6).each {subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from subproject.sourceSets.main.output.resourcesDir
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+}
+
+task extraBeesJar(type: Jar){
+    classifier = 'extrabees'
+    mainProjects.subList(6, 7).each {subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from subproject.sourceSets.main.output.resourcesDir
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+}
+
+task extraTreesJar(type: Jar){
+    classifier = 'extratrees'
+    mainProjects.subList(7, 9).each {subproject ->
+        from subproject.sourceSets.main.output.classesDirs
+        from subproject.sourceSets.api.output.classesDirs
+        from subproject.sourceSets.main.output.resourcesDir
+        from subproject.sourceSets.api.output.resourcesDir
+    }
+}
+
+task geneticsJar(type: Jar){
+    classifier = 'genetics'
+    mainProjects.subList(9, 11).each {subproject ->
         from subproject.sourceSets.main.output.classesDirs
         from subproject.sourceSets.api.output.classesDirs
         from subproject.sourceSets.main.output.resourcesDir
@@ -134,6 +197,12 @@ task copyJars(type: Copy) {
 
 artifacts {
     archives sourcesJar
+    archives coreJar
+    archives botanyJar
+    archives designJar
+    archives extraBeesJar
+    archives extraTreesJar
+    archives geneticsJar
 }
 
 uploadArchives {

--- a/extrabees/src/main/java/binnie/extrabees/ExtraBees.java
+++ b/extrabees/src/main/java/binnie/extrabees/ExtraBees.java
@@ -1,14 +1,11 @@
 package binnie.extrabees;
 
-import binnie.core.Binnie;
 import binnie.core.Constants;
-import binnie.core.api.genetics.IBreedingSystem;
 import binnie.core.gui.BinnieGUIHandler;
 import binnie.core.gui.IBinnieGUID;
 import binnie.core.modules.BlankModuleContainer;
 import binnie.core.network.BinniePacketHandler;
 import binnie.core.proxy.IProxyCore;
-import binnie.extrabees.genetics.BeeBreedingSystem;
 import binnie.extrabees.genetics.gui.analyst.AnalystPagePlugin;
 import binnie.extrabees.gui.ExtraBeesGUID;
 import binnie.extrabees.modules.ModuleCore;
@@ -17,7 +14,6 @@ import binnie.extrabees.utils.config.ConfigHandler;
 import binnie.extrabees.utils.config.ConfigurationMain;
 import binnie.genetics.api.GeneticsApi;
 import binnie.genetics.api.analyst.IAnalystManager;
-import forestry.api.apiculture.BeeManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
@@ -32,7 +28,7 @@ import java.io.File;
 	name = "Binnie's Extra Bees",
 	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
-	dependencies = "required-after:" + Constants.CORE_MOD_ID
+	dependencies = "required-after:" + Constants.CORE_MOD_ID + ';' + "required-after:" + Constants.GENETICS_MOD_ID + ';'
 )
 public class ExtraBees extends BlankModuleContainer {
 
@@ -43,8 +39,6 @@ public class ExtraBees extends BlankModuleContainer {
 
 	@SidedProxy(clientSide = "binnie.extrabees.proxy.ExtraBeesClientProxy", serverSide = "binnie.extrabees.proxy.ExtraBeesCommonProxy")
 	public static ExtraBeesCommonProxy proxy;
-
-	public static IBreedingSystem beeBreedingSystem;
 
 	public ExtraBees() {
 		super();
@@ -61,11 +55,6 @@ public class ExtraBees extends BlankModuleContainer {
 		configHandler.addConfigurable(new ConfigurationMain());
 
 		NetworkRegistry.INSTANCE.registerGuiHandler(this, new BinnieGUIHandler(ExtraBeesGUID.values()));
-
-		if (BeeManager.beeRoot != null) {
-			beeBreedingSystem = new BeeBreedingSystem();
-			Binnie.GENETICS.registerBreedingSystem(beeBreedingSystem);
-		}
 
 		IAnalystManager analystManager = GeneticsApi.analystManager;
 		if (analystManager != null) {

--- a/extrabees/src/main/java/binnie/extrabees/genetics/gui/analyst/AnalystPageBeeProducts.java
+++ b/extrabees/src/main/java/binnie/extrabees/genetics/gui/analyst/AnalystPageBeeProducts.java
@@ -17,7 +17,7 @@ import binnie.core.util.ForestryRecipeUtil;
 import binnie.core.util.I18N;
 import binnie.core.util.TimeUtil;
 import binnie.core.util.UniqueItemStackSet;
-import binnie.extrabees.ExtraBees;
+import binnie.genetics.api.GeneticsApi;
 import binnie.genetics.api.analyst.AnalystConstants;
 import binnie.genetics.api.analyst.IAnalystManager;
 import forestry.api.apiculture.BeeManager;
@@ -50,7 +50,7 @@ public class AnalystPageBeeProducts extends Control implements ITitledWidget {
 		new ControlTextCentered(this, y, TextFormatting.UNDERLINE + getTitle()).setColor(getColor());
 
 		y += 12;
-		new ControlTextCentered(this, y, TextFormatting.ITALIC + I18N.localise(AnalystConstants.PRODUCTS_KEY + ".rate") + ": " + ExtraBees.beeBreedingSystem.getAlleleName(EnumBeeChromosome.SPEED, ind.getGenome().getActiveAllele(EnumBeeChromosome.SPEED))).setColor(getColor());
+		new ControlTextCentered(this, y, TextFormatting.ITALIC + I18N.localise(AnalystConstants.PRODUCTS_KEY + ".rate") + ": " + GeneticsApi.beeBreedingSystem.getAlleleName(EnumBeeChromosome.SPEED, ind.getGenome().getActiveAllele(EnumBeeChromosome.SPEED))).setColor(getColor());
 
 		y += 20;
 		Collection<ItemStack> refinedProducts = new UniqueItemStackSet();

--- a/extrabees/src/main/java/binnie/extrabees/genetics/gui/database/WindowApiaristDatabase.java
+++ b/extrabees/src/main/java/binnie/extrabees/genetics/gui/database/WindowApiaristDatabase.java
@@ -15,13 +15,14 @@ import binnie.extrabees.ExtraBees;
 import binnie.extrabees.gui.PageSpeciesClimate;
 import binnie.extrabees.gui.PageSpeciesGenome;
 import binnie.extrabees.gui.PageSpeciesProducts;
+import binnie.genetics.api.GeneticsApi;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class WindowApiaristDatabase extends WindowAbstractDatabase {
 	public WindowApiaristDatabase(EntityPlayer player, Side side, boolean master) {
-		super(player, side, master, ExtraBees.beeBreedingSystem, 110);
+		super(player, side, master, GeneticsApi.beeBreedingSystem, 110);
 	}
 
 	public static Window create(EntityPlayer player, Side side, boolean master) {

--- a/extrabees/src/main/resources/mcmod.info
+++ b/extrabees/src/main/resources/mcmod.info
@@ -1,17 +1,16 @@
 [
   {
-    "modid": "binniecore",
-    "name": "Binnie Core",
-    "description": "Base mod for Binnie's Mods, with lots of common code.",
+    "modid": "extrabees",
+    "name": "Binnie's Extra Bees",
+    "description": "Adds new bees and products to expand the bee breeding in Forestry.",
     "version": "${version}",
     "mcversion": "${mcversion}",
     "url": "https://minecraft.curseforge.com/projects/binnies-mods",
     "updateUrl": "",
     "authorList": [ "Binnie" ],
     "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
-    "logoFile": "/assets/binniecore/logo.png",
+    "logoFile": "/assets/extrabees/logo.png",
     "parent": "",
-    "requiredMods": [ "forestry" ],
-    "dependencies": [ "forestry" ]
+    "dependencies": [ "BinnieCore" ]
   }
 ]

--- a/extratrees/src/main/java/binnie/extratrees/ExtraTrees.java
+++ b/extratrees/src/main/java/binnie/extratrees/ExtraTrees.java
@@ -1,16 +1,13 @@
 package binnie.extratrees;
 
-import binnie.core.Binnie;
 import binnie.core.BinnieCore;
 import binnie.core.Constants;
-import binnie.core.api.genetics.IBreedingSystem;
 import binnie.core.gui.IBinnieGUID;
 import binnie.core.machines.errors.ErrorStateRegistry;
 import binnie.core.modules.BlankModuleContainer;
 import binnie.core.network.BinniePacketHandler;
 import binnie.core.proxy.IProxyCore;
 import binnie.extratrees.config.ConfigurationMain;
-import binnie.extratrees.genetics.MothBreedingSystem;
 import binnie.extratrees.genetics.gui.analyst.ButterflyAnalystPagePlugin;
 import binnie.extratrees.genetics.gui.analyst.TreeAnalystPagePlugin;
 import binnie.extratrees.genetics.gui.analyst.TreeProducePlugin;
@@ -21,7 +18,6 @@ import binnie.extratrees.modules.ModuleWood;
 import binnie.extratrees.proxy.Proxy;
 import binnie.genetics.api.GeneticsApi;
 import binnie.genetics.api.analyst.IAnalystManager;
-import forestry.api.lepidopterology.ButterflyManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
@@ -35,7 +31,7 @@ import net.minecraftforge.oredict.OreDictionary;
 	name = "Binnie's Extra Trees",
 	version = "@VERSION@",
 	acceptedMinecraftVersions = Constants.ACCEPTED_MINECRAFT_VERSIONS,
-	dependencies = "required-after:" + Constants.CORE_MOD_ID + ';'
+	dependencies = "required-after:" + Constants.CORE_MOD_ID + ';' + "required-after:" + Constants.GENETICS_MOD_ID + ';'
 		+ "after:" + Constants.DESIGN_MOD_ID + ';'
 )
 public class ExtraTrees extends BlankModuleContainer {
@@ -47,7 +43,6 @@ public class ExtraTrees extends BlankModuleContainer {
 	@SuppressWarnings("NullableProblems")
 	@SidedProxy(clientSide = "binnie.extratrees.proxy.ProxyClient", serverSide = "binnie.extratrees.proxy.ProxyServer")
 	public static Proxy proxy;
-	public static IBreedingSystem mothBreedingSystem;
 
 	public ExtraTrees() {
 		super();
@@ -58,11 +53,6 @@ public class ExtraTrees extends BlankModuleContainer {
 	public void preInit(final FMLPreInitializationEvent evt) {
 		container.registerConfigHandler(new ConfigurationMain(container));
 		super.preInit(evt);
-
-		if (ButterflyManager.butterflyRoot != null) {
-			mothBreedingSystem = new MothBreedingSystem();
-			Binnie.GENETICS.registerBreedingSystem(mothBreedingSystem);
-		}
 
 		IAnalystManager analystManager = GeneticsApi.analystManager;
 		if (analystManager != null) {

--- a/extratrees/src/main/java/binnie/extratrees/carpentry/GlassType.java
+++ b/extratrees/src/main/java/binnie/extratrees/carpentry/GlassType.java
@@ -7,6 +7,8 @@ import binnie.design.api.IDesignMaterial;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
 import javax.annotation.Nullable;
@@ -28,6 +30,13 @@ public class GlassType implements IDesignMaterial {
 		for (final StandardColor c : StandardColor.values()) {
 			GlassType.types.put(c.ordinal(), new GlassType(c.ordinal(), c.name, c.colour));
 		}
+		if (Loader.isModLoaded(Constants.BOTANY_MOD_ID)) {
+			doBotany();
+		}
+	}
+
+	@Optional.Method(modid = Constants.BOTANY_MOD_ID)
+	private static void doBotany(){
 		for (final EnumFlowerColor c2 : EnumFlowerColor.values()) {
 			GlassType.types.put(128 + c2.ordinal(), new GlassType(128 + c2.ordinal(), c2.getFlowerColorAllele().getColorName(), c2.getFlowerColorAllele().getColor(false)));
 		}

--- a/extratrees/src/main/java/binnie/extratrees/genetics/gui/analyst/ButterflyAnalystPagePlugin.java
+++ b/extratrees/src/main/java/binnie/extratrees/genetics/gui/analyst/ButterflyAnalystPagePlugin.java
@@ -11,7 +11,7 @@ import binnie.core.gui.geometry.TextJustification;
 import binnie.core.gui.minecraft.control.ControlIconDisplay;
 import binnie.core.util.I18N;
 import binnie.core.util.TimeUtil;
-import binnie.extratrees.ExtraTrees;
+import binnie.genetics.api.GeneticsApi;
 import binnie.genetics.api.analyst.AnalystConstants;
 import binnie.genetics.api.analyst.IAnalystIcons;
 import binnie.genetics.api.analyst.IAnalystManager;
@@ -116,7 +116,7 @@ public class ButterflyAnalystPagePlugin implements IAnalystPagePlugin<IButterfly
 		@Override
 		public int addBehaviourPages(IButterfly individual, IWidget parent, int y) {
 			IButterflyGenome genome = individual.getGenome();
-			String metabolismAlleleName = ExtraTrees.mothBreedingSystem.getAlleleName(EnumButterflyChromosome.METABOLISM, genome.getActiveAllele(EnumButterflyChromosome.METABOLISM));
+			String metabolismAlleleName = GeneticsApi.mothBreedingSystem.getAlleleName(EnumButterflyChromosome.METABOLISM, genome.getActiveAllele(EnumButterflyChromosome.METABOLISM));
 			new ControlTextCentered(parent, y, I18N.localise(AnalystConstants.BEHAVIOUR_KEY + ".metabolism", metabolismAlleleName))
 				.setColor(parent.getColor());
 			y += 20;

--- a/extratrees/src/main/java/binnie/extratrees/gui/database/WindowLepidopteristDatabase.java
+++ b/extratrees/src/main/java/binnie/extratrees/gui/database/WindowLepidopteristDatabase.java
@@ -11,13 +11,14 @@ import binnie.core.gui.database.PageSpeciesResultant;
 import binnie.core.gui.database.WindowAbstractDatabase;
 import binnie.core.gui.minecraft.Window;
 import binnie.extratrees.ExtraTrees;
+import binnie.genetics.api.GeneticsApi;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class WindowLepidopteristDatabase extends WindowAbstractDatabase {
 	public WindowLepidopteristDatabase(EntityPlayer player, Side side, boolean master) {
-		super(player, side, master, ExtraTrees.mothBreedingSystem, 160);
+		super(player, side, master, GeneticsApi.mothBreedingSystem, 160);
 	}
 
 	public static Window create(EntityPlayer player, Side side, boolean master) {

--- a/extratrees/src/main/resources/mcmod.info
+++ b/extratrees/src/main/resources/mcmod.info
@@ -1,17 +1,16 @@
 [
   {
-    "modid": "binniecore",
-    "name": "Binnie Core",
-    "description": "Base mod for Binnie's Mods, with lots of common code.",
+    "modid": "extratrees",
+    "name": "Binnie's Extra Trees",
+    "description": "Adds new trees, aesthetic blocks and alcohol production.",
     "version": "${version}",
     "mcversion": "${mcversion}",
     "url": "https://minecraft.curseforge.com/projects/binnies-mods",
     "updateUrl": "",
     "authorList": [ "Binnie" ],
     "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
-    "logoFile": "/assets/binniecore/logo.png",
+    "logoFile": "/assets/extratrees/logo.png",
     "parent": "",
-    "requiredMods": [ "forestry" ],
-    "dependencies": [ "forestry" ]
+    "dependencies": [ "BinnieCore" ]
   }
 ]

--- a/genetics-api/src/main/java/binnie/genetics/api/GeneticsApi.java
+++ b/genetics-api/src/main/java/binnie/genetics/api/GeneticsApi.java
@@ -1,5 +1,6 @@
 package binnie.genetics.api;
 
+import binnie.core.api.genetics.IBreedingSystem;
 import binnie.genetics.api.acclimatiser.IAcclimatiserManager;
 import binnie.genetics.api.analyst.IAnalystManager;
 
@@ -11,4 +12,7 @@ public class GeneticsApi {
 
 	@Nullable
 	public static IAnalystManager analystManager;
+
+    public static IBreedingSystem beeBreedingSystem;
+	public static IBreedingSystem mothBreedingSystem;
 }

--- a/genetics/src/main/java/binnie/genetics/Genetics.java
+++ b/genetics/src/main/java/binnie/genetics/Genetics.java
@@ -17,6 +17,8 @@ import binnie.genetics.config.ConfigurationMain;
 import binnie.genetics.core.GeneticsGUI;
 import binnie.genetics.core.GeneticsPacket;
 import binnie.genetics.core.GeneticsTexture;
+import binnie.genetics.genetics.BeeBreedingSystem;
+import binnie.genetics.genetics.MothBreedingSystem;
 import binnie.genetics.genetics.TreeBreedingSystem;
 import binnie.genetics.gui.Icons;
 import binnie.genetics.gui.analyst.AnalystManager;
@@ -27,7 +29,9 @@ import binnie.genetics.machine.acclimatiser.AcclimatiserManager;
 import binnie.genetics.machine.sequencer.Sequencer;
 import binnie.genetics.proxy.Proxy;
 import com.google.common.base.Preconditions;
+import forestry.api.apiculture.BeeManager;
 import forestry.api.arboriculture.TreeManager;
+import forestry.api.lepidopterology.ButterflyManager;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -79,6 +83,16 @@ public class Genetics extends BlankModuleContainer {
 		configHandler = new ConfigHandler(configFile);
 		configHandler.addConfigurable(new ConfigurationMain());
 
+
+		if (BeeManager.beeRoot != null) {
+			GeneticsApi.beeBreedingSystem = new BeeBreedingSystem();
+			Binnie.GENETICS.registerBreedingSystem(GeneticsApi.beeBreedingSystem);
+		}
+
+		if (ButterflyManager.butterflyRoot != null) {
+			GeneticsApi.mothBreedingSystem = new MothBreedingSystem();
+			Binnie.GENETICS.registerBreedingSystem(GeneticsApi.mothBreedingSystem);
+		}
 
 		if (TreeManager.treeRoot != null) {
 			TreeBreedingSystem treeBreedingSystem = new TreeBreedingSystem();

--- a/genetics/src/main/java/binnie/genetics/genetics/BeeBreedingSystem.java
+++ b/genetics/src/main/java/binnie/genetics/genetics/BeeBreedingSystem.java
@@ -1,4 +1,4 @@
-package binnie.extrabees.genetics;
+package binnie.genetics.genetics;
 
 import binnie.core.Binnie;
 import binnie.core.api.genetics.IFieldKitPlugin;

--- a/genetics/src/main/java/binnie/genetics/genetics/MothBreedingSystem.java
+++ b/genetics/src/main/java/binnie/genetics/genetics/MothBreedingSystem.java
@@ -1,6 +1,7 @@
-package binnie.extratrees.genetics;
+package binnie.genetics.genetics;
 
 import binnie.core.Binnie;
+import binnie.core.Constants;
 import binnie.core.ModId;
 import binnie.core.api.genetics.IFieldKitPlugin;
 import binnie.core.api.gui.IPoint;
@@ -12,7 +13,6 @@ import binnie.core.gui.geometry.Point;
 import binnie.core.gui.resource.textures.StandardTexture;
 import binnie.core.texture.BinnieCoreTexture;
 import binnie.core.util.I18N;
-import binnie.extratrees.ExtraTrees;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IAlleleInteger;
 import forestry.api.genetics.IAlleleSpecies;
@@ -34,8 +34,8 @@ import java.util.TreeSet;
 
 public class MothBreedingSystem extends BreedingSystem {
 	public MothBreedingSystem() {
-		this.iconUndiscovered = Binnie.RESOURCE.getItemSprite(ExtraTrees.instance, "icon/undiscovered_moth");
-		this.iconDiscovered = Binnie.RESOURCE.getItemSprite(ExtraTrees.instance, "icon/discovered_moth");
+		this.iconUndiscovered = Binnie.RESOURCE.getItemSprite(Constants.EXTRA_TREES_MOD_ID, "icon/undiscovered_moth");
+		this.iconDiscovered = Binnie.RESOURCE.getItemSprite(Constants.EXTRA_TREES_MOD_ID, "icon/discovered_moth");
 	}
 
 	@Override

--- a/genetics/src/main/resources/mcmod.info
+++ b/genetics/src/main/resources/mcmod.info
@@ -1,17 +1,16 @@
 [
   {
-    "modid": "binniecore",
-    "name": "Binnie Core",
-    "description": "Base mod for Binnie's Mods, with lots of common code.",
+    "modid": "genetics",
+    "name": "Binnie's Genetics",
+    "description": "Adds genetic manipulation for bees, trees, butterflies and flowers.",
     "version": "${version}",
     "mcversion": "${mcversion}",
     "url": "https://minecraft.curseforge.com/projects/binnies-mods",
     "updateUrl": "",
     "authorList": [ "Binnie" ],
     "credits": "Thanks to Sengir, MysteriousAges, Xizzzy and many others",
-    "logoFile": "/assets/binniecore/logo.png",
+    "logoFile": "/assets/genetics/logo.png",
     "parent": "",
-    "requiredMods": [ "forestry" ],
-    "dependencies": [ "forestry" ]
+    "dependencies": [ "BinnieCore" ]
   }
 ]


### PR DESCRIPTION
I made it possible to choose to not have botany, extra bees, or extra trees, however I haven't touched separating genetics from extra trees/bees since that one is a bit more complicated, and I also didn't touch design.  So for now I've just made the bees and trees require genetics. I also moved the bee and moth breeding system classes and their static instances into Genetics since without extra bees/trees it would cause an illegal state exception for those systems not existing for the bees and butterflies species roots, even though logically it shouldn't be an issue cause forestry by itself already has butterflies and bees.

The separate jars build, but they build as deobsficated, which is not good, and I also noticed that the sub projects make builds, but I didn't just use those cause the non api ones don't include the api, and I don't know how to include from an outside source in those builds without using some gradle plugin to do that. If you have any better suggestions on how to do the building I'm all ears.

As for why I'm doing this now? cause I wanted a way to be able to use this mod in our pack while still only requiring 4 gigs, and the entirety of binnies jumped the ram usage up like a gig when it was added, so as is it wasn't usable.
